### PR TITLE
Add coveralls configuration to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ before_install:
     - "./.travis.sh"
 
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+    - pip install -r requirements.txt
+    - pip install coveralls
 
 # command to run tests
-script: cd tests && python test_core.py
+script:
+    coverage run --source=quit tests/test_core.py
+
+after_success:
+    coveralls


### PR DESCRIPTION
Coverage is executed with
https://pypi.python.org/pypi/coverage/
and integrated in coveralls
https://pypi.python.org/pypi/coveralls
and reported at
https://coveralls.io/github/AKSW/QuitStore