### PR TITLE
Update GitRepo to use pygit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The `config.ttl` could as well be put under version controll for collaboration, 
 
 ## Run from command line
 
+Install [libgit2](https://libgit2.github.com/) needed for pygit2 bindings.
 Install [pip](https://pypi.python.org/pypi/pip/) and optionally [virtualenv resp. virtualenvwrapper](http://virtualenvwrapper.readthedocs.io/en/latest/install.html):
 ```
 pip install virtualenv

--- a/quit/conf.py
+++ b/quit/conf.py
@@ -21,6 +21,7 @@ class QuitConfiguration:
         self.gc = gc
         self.graphs = {}
         self.files = {}
+        self.pathspec = []
 
         if isfile(configfile):
             try:
@@ -75,6 +76,7 @@ class QuitConfiguration:
             filename = str(row['filename'])
 
             if isfile(join(self.gitrepo, filename)):
+                self.pathspec.append(filename)
                 filename = join(self.gitrepo, filename)
             elif isfile(filename) is False:
                 pass
@@ -161,6 +163,10 @@ class QuitConfiguration:
         """
 
         return self.graphs
+
+    def getpathspec(self):
+        """Get pathspec from config."""
+        return self.pathspec
 
     def getserializationoffile(self, file):
         """Get the file for a given graph uri.

--- a/quit/core.py
+++ b/quit/core.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 
 from datetime import datetime
-import git
 import logging
 from os.path import abspath
 from quit.update import evalUpdate
+from pygit2 import GIT_MERGE_ANALYSIS_UP_TO_DATE
+from pygit2 import GIT_MERGE_ANALYSIS_FASTFORWARD
+from pygit2 import GIT_MERGE_ANALYSIS_NORMAL
+from pygit2 import GIT_SORT_REVERSE, GIT_RESET_HARD, GIT_STATUS_CURRENT, init_repository
+from pygit2 import Repository, Signature
+from os.path import isdir, join
 from rdflib import ConjunctiveGraph, Graph, URIRef, BNode
-import subprocess
 
 corelogger = logging.getLogger('core.quit')
+
 
 class FileReference:
     """A class that manages n-quad files.
@@ -320,72 +325,49 @@ class GitRepo:
     You can stage and commit files and checkout different commits of the repository.
     """
 
-    commits = []
-    ids = []
+    path = ''
+    author = Signature('QuitStore', 'quit@quit.aksw.org')
+    comitter = Signature('QuitStore', 'quit@quit.aksw.org')
 
     def __init__(self, path):
-        """Initialize a new repository.
+        """Initialize a new repository from an existing directory.
 
         Args:
             path: A string containing the path to the repository.
-
-        Raises:
-            Exception if path is not a git repository.
         """
         self.logger = logging.getLogger('git_repo.core.quit')
-        self.logger.debug('Create an instance of GitStore')
+        self.logger.debug('GitRepo, init, Create an instance of GitStore')
         self.path = path
 
         try:
-            self.repo = git.Repo(self.path)
+            if isdir(join(path, '.git')):
+                repo = Repository(path)
+            else:
+                repo = init_repository(path, False)
+            self.repo = repo
         except:
             raise
 
-        self.git = self.repo.git
-        self.__setcommits()
-
-        return
-
-    def __setcommits(self):
-        """Save a list of all git commits, commit messages and dates."""
-        commits = []
-        ids = []
-        log = self.repo.iter_commits('master')
-
-        try:
-            for entry in log:
-                # extract timestamp and convert to datetime
-                commitdate = datetime.fromtimestamp(float(entry.committed_date)).strftime('%Y-%m-%d %H:%M:%S')
-                ids.append(str(entry))
-                commits.append({
-                    'id': str(entry),
-                    'message': str(entry.message),
-                    'committeddate': commitdate
-                })
-        except:
-            pass
-
-        self.commits = commits
-        self.ids = ids
-
-        return
+    def addall(self):
+        """Add all (newly created|changed) files to index."""
+        self.repo.index.read()
+        self.repo.index.add_all()
+        self.repo.index.write()
 
     def addfile(self, filename):
-        """Add a file that should be tracked.
+        """Add a file to the index.
 
         Args:
             filename: A string containing the path to the file.
-        Raises:
-            Exception: If file was not found under 'filename' or if file is part of store.
         """
-        gitstatus = self.git.status('--porcelain')
+        index = self.repo.index
+        index.read()
 
         try:
-            self.git.add([filename])
-            return True
+            index.add(filename)
+            index.write()
         except:
-            self.logger.debug('Couldn\'t add file', filename)
-            return False
+            self.logger.debug('GitRepo, addfile, Couldn\'t add file', filename)
 
     def addremote(self, name, url):
         """Add a remote.
@@ -395,13 +377,10 @@ class GitRepo:
             url: A string containing the url to the remote.
         """
         try:
-            self.repo.create_remote(name, url)
-            self.logger.debug('Successful added remote', name, url)
+            self.repo.remotes.create(name, url)
+            self.logger.debug('GitRepo, addremote, Successful added remote', name, url)
         except:
-            return False
-            self.logger.debug('Could not add remote', name, url)
-
-        return True
+            self.logger.debug('GitRepo, addremote, Could not add remote', name, url)
 
     def checkout(self, commitid):
         """Checkout a commit by a commit id.
@@ -410,13 +389,12 @@ class GitRepo:
             commitid: A string cotaining a commitid.
         """
         try:
-            self.logger.debug('Checked out commit:', commitid)
-            self.git.checkout(commitid)
+            commit = self.repo.revparse_single(commitid)
+            self.repo.set_head(commit.oid)
+            self.repo.reset(commit.oid, GIT_RESET_HARD)
+            self.logger.debug('GitRepo, checkout, Checked out commit:', commitid)
         except:
-            self.logger.debug('Commit-ID (' + commitid + ') does not exist')
-            return False
-
-        return True
+            self.logger.debug('GitRepo, checkout, Commit-ID (' + commitid + ') does not exist')
 
     def commit(self, message=None):
         """Commit staged files.
@@ -426,22 +404,36 @@ class GitRepo:
         Raises:
             Exception: If no files in staging area.
         """
-        if message is None:
-            message = '\"New commit from quit-store\"'
+        if self.isstagingareaclean():
+            # nothing to commit
+            return
 
-        # TODO Add a meta data
-        # committer = str.encode('Quit-Store <quit.store@aksw.org>')
-        # commitid = self.repo.do_commit(msg, committer)
+        if message is None:
+            message = 'New commit from quit-store'
+
+        # tree = self.repo.TreeBuilder().write()
+
+        index = self.repo.index
+        index.read()
+        tree = index.write_tree()
 
         try:
-            self.git.commit('-m', message)
-            self.__setcommits()
-            self.logger.debug('Updates commited')
-        except git.exc.GitCommandError:
-            self.logger.debug('Nothing to commit')
-            return False
-
-        return True
+            if len(self.repo.listall_reference_objects()) == 0:
+                # Initial Commit
+                message = message + " Initial Commit from QuitStore"
+                self.repo.create_commit('HEAD',
+                                        self.author, self.comitter, message,
+                                        tree,
+                                        [])
+            else:
+                self.repo.create_commit('HEAD',
+                                        self.author, self.comitter, message,
+                                        tree,
+                                        [self.repo.head.get_object().hex]
+                                        )
+            self.logger.debug('GitRepo, commit, Updates commited')
+        except:
+            self.logger.debug('GitRepo, commit, Nothing to commit')
 
     def commitexists(self, commitid):
         """Check if a commit id is part of the repository history.
@@ -452,7 +444,7 @@ class GitRepo:
             True, if commitid is part of commit log
             False, else.
         """
-        if commitid in self.ids:
+        if commitid in self.getids():
             return True
         else:
             return False
@@ -463,12 +455,21 @@ class GitRepo:
         Args:
             commitid: A string cotaining a commitid.
         """
+        '''
         try:
             self.git.gc('--auto', '--quiet')
         except:
             print('Garbage collection failed')
-
+        '''
         return
+
+    def getpath(self):
+        """Return the path of the git repository.
+
+        Returns:
+            A string containing the path to the directory of git repo
+        """
+        return self.path
 
     def getcommits(self):
         """Return meta data about exitsting commits.
@@ -476,7 +477,33 @@ class GitRepo:
         Returns:
             A list containing dictionaries with commit meta data
         """
-        return self.commits
+        commits = []
+        if len(self.repo.listall_reference_objects()) > 0:
+            for commit in self.repo.walk(self.repo.head.target, GIT_SORT_REVERSE):
+                # commitdate = datetime.fromtimestamp(float(commit.date)).strftime('%Y-%m-%d %H:%M:%S')
+                commits.append({
+                    'id': str(commit.oid),
+                    'message': str(commit.message),
+                    'commit_date': datetime.fromtimestamp(
+                        commit.commit_time).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'author_name': commit.author.name,
+                    'author_email': commit.author.email,
+                    'parents': [c.hex for c in commit.parents],
+                    }
+                )
+        return commits
+
+    def getids(self):
+        """Return meta data about exitsting commits.
+
+        Returns:
+            A list containing dictionaries with commit meta data
+        """
+        ids = []
+        if len(self.repo.listall_reference_objects()) > 0:
+            for commit in self.repo.walk(self.repo.head.target, GIT_SORT_REVERSE):
+                ids.append(str(commit.oid))
+        return ids
 
     def isstagingareaclean(self):
         """Check if staging area is clean.
@@ -485,17 +512,13 @@ class GitRepo:
             True, if staginarea is clean
             False, else.
         """
-        try:
-            self.repo.head.commit.tree
-            gitstatus = self.git.diff('HEAD', '--name-only')
-        except:
-            # A fresh initialized repository
-            return False
+        status = self.repo.status()
 
-        if gitstatus == '':
-            return True
+        for filepath, flags in status.items():
+            if flags != GIT_STATUS_CURRENT:
+                return False
 
-        return False
+        return True
 
     def pull(self, remote='origin', branch='master'):
         """Pull if possible.
@@ -504,20 +527,37 @@ class GitRepo:
             True: If successful.
             False: If merge not possible or no updates from remote.
         """
-        self.git.fetch(remote, branch)
-        idhead = self.git.rev_parse('HEAD')
-        idfetchhead = self.git.rev_parse('FETCH_HEAD')
-        idbase = self.git.merge_base('HEAD', 'FETCH_HEAD')
-
         try:
-            if idhead == idbase and idhead != idfetchhead:
-                pull = self.git.merge('FETCH_HEAD')
-                if 'Already up-to-date' not in pull:
-                    return True
-        except git.exc.GitCommandError:
-            pass
+            self.repo.remotes[remote].fetch()
+        except:
+            self.logger.debug('GitRepo, pull,  No remote', remote)
 
-        return False
+        ref = 'refs/remotes/' + remote + '/' + branch
+        remoteid = self.repo.lookup_reference(ref).target
+        analysis, _ = self.repo.merge_analysis(remoteid)
+
+        if analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE:
+            # Already up-to-date
+            pass
+        elif analysis & GIT_MERGE_ANALYSIS_FASTFORWARD:
+            # fastforward
+            self.repo.checkout_tree(self.repo.get(remoteid))
+            master_ref = self.repo.lookup_reference('refs/heads/master')
+            master_ref.set_target(remoteid)
+            self.repo.head.set_target(remoteid)
+        elif analysis & GIT_MERGE_ANALYSIS_NORMAL:
+            self.repo.merge(remoteid)
+            tree = self.repo.index.write_tree()
+            msg = 'Merge from ' + remote + ' ' + branch
+            self.repo.create_commit('HEAD',
+                                    self.author,
+                                    self.comitter,
+                                    msg,
+                                    tree,
+                                    [self.repo.head.target, remoteid])
+            self.repo.state_cleanup()
+        else:
+            self.logger.debug('GitRepo, pull, Unknown merge analysis result')
 
     def push(self, remote='origin', branch='master'):
         """Push if possible.
@@ -526,39 +566,25 @@ class GitRepo:
             True: If successful.
             False: If diverged or nothing to push.
         """
-        self.git.fetch('--all')
-        idhead = self.git.rev_parse('HEAD')
-        idfetchhead = self.git.rev_parse('FETCH_HEAD')
-        idbase =self.git.merge_base('HEAD', 'FETCH_HEAD')
+        ref = ['refs/heads/' + branch]
 
         try:
-            if idhead != idfetchhead and idbase == idfetchhead:
-                push = self.git.push('--porcelain', remote, branch)
-                if 'error: ' not in push or '[rejected]' not in push:
-                    return True
-        except git.exc.GitCommandError:
-            pass
-
-        return False
-
-    def update(self, push=False):
-        """Try to add all updated files.
-
-        Raises:
-            Exception: If no tracked file was changed.
-        """
-        gitstatus = self.git.status('--porcelain')
-
-        if gitstatus == '':
-            self.logger.debug('Nothing to add')
-            return False
-
-        try:
-            self.logger.debug('Staging file(s)')
-            self.git.add([''], '-u')
-            if push:
-                self.git.push()
+            remo = self.repo.remotes[remote]
         except:
-            return False
+            self.logger.debug('GitRepo, push, Remote:', remote, 'does not exist')
+            return
 
-        return True
+        try:
+            remo.push(ref)
+        except:
+            self.logger.debug('GitRepo, push, Can not push to', remote, 'with ref', ref)
+
+    def setpushurl(self, remote, url):
+        """Set the URL where to push to."""
+        try:
+            remotetest = self.repo.remotes[remote]
+        except:
+            self.logger.debug('GitRepo, setpushurl, Remote:', remote, 'does not exist')
+            return
+
+        remotetest.set_push_url = url

--- a/quit/core.py
+++ b/quit/core.py
@@ -326,10 +326,11 @@ class GitRepo:
     """
 
     path = ''
+    pathspec = []
     author = Signature('QuitStore', 'quit@quit.aksw.org')
     comitter = Signature('QuitStore', 'quit@quit.aksw.org')
 
-    def __init__(self, path):
+    def __init__(self, path, pathspec=[]):
         """Initialize a new repository from an existing directory.
 
         Args:
@@ -337,6 +338,7 @@ class GitRepo:
         """
         self.logger = logging.getLogger('git_repo.core.quit')
         self.logger.debug('GitRepo, init, Create an instance of GitStore')
+        self.pathspec = pathspec
         self.path = path
 
         try:
@@ -351,7 +353,7 @@ class GitRepo:
     def addall(self):
         """Add all (newly created|changed) files to index."""
         self.repo.index.read()
-        self.repo.index.add_all()
+        self.repo.index.add_all(self.pathspec)
         self.repo.index.write()
 
     def addfile(self, filename):

--- a/quit/quit.py
+++ b/quit/quit.py
@@ -42,6 +42,7 @@ ch.setFormatter(formatter)
 logger.addHandler(fh)
 logger.addHandler(ch)
 
+
 def __savefiles():
     """Update the files after a update query was executed on the store."""
     for file in config.getfiles():
@@ -59,7 +60,7 @@ def __savefiles():
 
 def __updategit():
     """Private method to add all updated tracked files."""
-    gitrepo.update()
+    gitrepo.addall()
     gitrepo.commit()
     if config.isgarbagecollectionon():
         gitrepo.garbagecollection()
@@ -374,7 +375,6 @@ def savedexit():
 API
 '''
 
-
 @app.route("/sparql", methods=['POST', 'GET'])
 def sparql():
     """Process a SPARQL query (Select or Update).
@@ -579,6 +579,7 @@ def resultFormat():
 def main():
     """Start the app."""
     app.run(debug=True, use_reloader=False)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/quit/quit.py
+++ b/quit/quit.py
@@ -197,7 +197,11 @@ def initialize(args):
     store = MemoryStore()
 
     files = config.getfiles()
-    gitrepo = GitRepo(config.getrepopath())
+
+    if args.pathspec:
+        gitrepo = GitRepo(config.getrepopath(), config.getpathspec())
+    else:
+        gitrepo = GitRepo(config.getrepopath())
 
     # Load data to store
     for filename in files:
@@ -585,6 +589,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-nv', '--disableversioning', action='store_true')
     parser.add_argument('-gc', '--garbagecollection', action='store_true')
+    parser.add_argument('-ps', '--pathspec', action='store_true')
     args = parser.parse_args()
 
     objects = initialize(args)

--- a/quit/quit.py
+++ b/quit/quit.py
@@ -298,8 +298,9 @@ def processsparql(querystring):
 
         if config.isversioningon():
             actions = store.update(query)
-            applyupdates(actions)
-            __updategit()
+            if len(actions) > 0:
+                applyupdates(actions)
+                __updategit()
             return
         else:
             store.update(query, versioning=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ Flask-API==0.6.4
 pyyaml
 rdflib==4.2.1
 rfc3987
-dulwich
-GitPython
 flask-cors
 pygit2


### PR DESCRIPTION
This commit changes the git library from GitPython to pygit2.
With this commit the installation of QuitStore changes and libgit2 is needed to fulfill the requirements of pygit2.