### PR TITLE
Issue13

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 cd ~
 
-git clone --depth=1 -b maint/v0.24 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b maint/v0.25 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 rdflib==4.2.1
 rfc3987
 flask-cors
-pygit2
+pygit2==0.25.0


### PR DESCRIPTION
Fix #13 
Pip's requirements.txt used to point to 0.24.0 of pygit2 and switched to 0.25.0 whicht doesn't match the verison of libit2 (0.24.0). With this pull request QuitStore will use 0.25.0 for both, pygit2 and libgit2.
