### PR TITLE
Fix Flask CORS warning

### DIFF
--- a/quit/web/app.py
+++ b/quit/web/app.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 from flask import Flask, render_template as rt, render_template_string as rts, g, current_app
 from flask import request, url_for, redirect, make_response
-from flask.ext.cors import CORS
+from flask_cors import CORS
 
 from jinja2 import Environment, contextfilter, Markup
 


### PR DESCRIPTION
Fix the warning

    …/quit/web/app.py:12: ExtDeprecationWarning: Importing flask.ext.cors is deprecated, use flask_cors instead.
      from flask.ext.cors import CORS
