### PR TITLE
Add callback method for reporting if a remote rejectes a push

### DIFF
--- a/quit/git.py
+++ b/quit/git.py
@@ -554,3 +554,10 @@ class QuitRemoteCallbacks (pygit2.RemoteCallbacks):
                 )
         else:
             raise Exception("Only unsupported credential types allowed by remote end")
+
+    def push_update_reference(self, refname, message):
+        if message:
+            raise QuitGitPushError(
+                "The reference \"{}\" could not be pushed. Remote tells us: {}".format(
+                    refname, message))
+        pass

--- a/quit/git.py
+++ b/quit/git.py
@@ -558,9 +558,9 @@ class QuitRemoteCallbacks (pygit2.RemoteCallbacks):
             raise Exception("Only unsupported credential types allowed by remote end")
 
     def push_update_reference(self, refname, message):
-        """This callback is called if for a push.
+        """This callback is called for a push operation.
 
-        In the case, that te remote rejects a push, message will be set.
+        In the case, that the remote rejects a push, message will be set.
         Because we can't raise an Exception here, we have to write it to self.push_error, thus it is
         important to check on the callback object if push_error is not None after a push.
         """

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -316,13 +316,13 @@ class GitRepositoryTests(unittest.TestCase):
                 with self.assertRaises(pygit2.GitError):
                     quitRepo.push()
 
+    @unittest.skip("requires a remote with pre-receive hook")
     def testPushRepoWithRemoteReject(self):
         """Test for an exception, if the remote repositories rejects a push.
 
         CAUTION: This test is disabled, because it requires a remote with pre-receive hook.
         Unfortunately the libgit2 does not execute pre-receive hooks on local repositories.
         """
-        return
         graphContent = """
             <http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."""
         with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as local:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -285,7 +285,7 @@ class GitRepositoryTests(unittest.TestCase):
 
     def testPushRepoNotConfiguredNamedRemote(self):
         """Test if the push failes if the specified remote was not defined."""
-        with TemporaryRepository(True) as remote:
+        with TemporaryRepository(is_bare=True) as remote:
             graphContent = """
                 <http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."""
             with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as local:
@@ -315,6 +315,24 @@ class GitRepositoryTests(unittest.TestCase):
 
                 with self.assertRaises(pygit2.GitError):
                     quitRepo.push()
+
+    def testPushRepoWithRemoteReject(self):
+        """Test for an exception, if the remote repositories rejects a push.
+
+        CAUTION: This test is disabled, because it requires a remote with pre-receive hook.
+        Unfortunately the libgit2 does not execute pre-receive hooks on local repositories.
+        """
+        return
+        graphContent = """
+            <http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."""
+        with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as local:
+            local.remotes.create("origin", "ssh://git@git.docker/testing.git")
+            quitRepo = quit.git.Repository(local.workdir)
+
+            self.assertFalse(local.is_empty)
+
+            with self.assertRaises(QuitGitPushError):
+                quitRepo.push()
 
     def testRepositoryIsEmpty(self):
         """Test that adding data causes a new commit."""


### PR DESCRIPTION
TODO:
- [x] Add tests for this case.

The test was disabled, because we are not yet able to run a remote which executes hooks in our test environment.