### PR TITLE
Change __all__ to tuples

### DIFF
--- a/quit/namespace.py
+++ b/quit/namespace.py
@@ -1,6 +1,6 @@
 from rdflib.namespace import Namespace, RDF, RDFS, FOAF, DC, VOID, XSD
 
-__all__ = ['RDF', 'RDFS', 'FOAF', 'DC', 'VOID', 'XSD', 'PROV', 'QUIT', 'is_a']
+__all__ = ('RDF', 'RDFS', 'FOAF', 'DC', 'VOID', 'XSD', 'PROV', 'QUIT', 'is_a')
 
 # missing namespaces
 PROV = Namespace('http://www.w3.org/ns/prov#')

--- a/quit/plugins/serializers/results/htmlresults.py
+++ b/quit/plugins/serializers/results/htmlresults.py
@@ -40,7 +40,7 @@ import rdflib
 from jinja2 import Environment, contextfilter, Markup
 from rdflib.query import ResultSerializer
 
-__all__ = ['HTMLResultSerializer']
+__all__ = ('HTMLResultSerializer')
 
 namespace_manager = rdflib.Graph().namespace_manager
 namespace_manager.bind('xsd', rdflib.XSD)

--- a/quit/web/app.py
+++ b/quit/web/app.py
@@ -25,7 +25,7 @@ from quit.provenance import Blame
 logger = logging.getLogger('quit.web.app')
 
 # For import *
-__all__ = ['create_app']
+__all__ = ('create_app')
 
 DROPDOWN_TEMPLATE = """
 <div class="dropdown branch-select">

--- a/quit/web/modules/debug.py
+++ b/quit/web/modules/debug.py
@@ -6,7 +6,7 @@ from flask import Blueprint, flash, redirect, request, url_for, current_app, mak
 from quit.conf import Feature
 from quit.web.app import render_template, feature_required
 
-__all__ = ['debug']
+__all__ = ('debug')
 
 debug = Blueprint('debug', __name__)
 

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -11,7 +11,7 @@ from quit.exceptions import UnSupportedQueryType
 
 logger = logging.getLogger('quit.modules.endpoint')
 
-__all__ = ['endpoint']
+__all__ = ('endpoint')
 
 endpoint = Blueprint('endpoint', __name__)
 

--- a/quit/web/modules/git.py
+++ b/quit/web/modules/git.py
@@ -10,7 +10,7 @@ from quit.web.extras.commits_graph import CommitGraph, generate_graph_data
 from quit.utils import git_timestamp
 import json
 
-__all__ = ['git']
+__all__ = ('git')
 
 git = Blueprint('git', __name__)
 


### PR DESCRIPTION
To prevent the warning:

> WARNING: all is defined as a list, this means pydocstyle cannot reliably detect contents of the all variable, because it can be mutated. Change all to be an (immutable) tuple, to remove this warning. Note, pydocstyle uses all to detect which definitions are public, to warn if public definitions are missing docstrings. If all is a (mutable) list, pydocstyle cannot reliably assume its contents. pydocstyle will proceed assuming all is not mutated.

the `__all__` "variables" are changed to tuples.