### PR TITLE
Queries with SPARQL keywords in PREFIX will fail.

### DIFF
--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -5,6 +5,8 @@ import logging
 from werkzeug.http import parse_accept_header
 from flask import Blueprint, request, current_app, make_response, Markup
 from rdflib import ConjunctiveGraph
+from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
+from rdflib.plugins.sparql.algebra import translateQuery, translateUpdate
 from quit.conf import Feature
 from quit.web.app import render_template, feature_required
 from quit.exceptions import UnSupportedQueryType
@@ -14,15 +16,6 @@ logger = logging.getLogger('quit.modules.endpoint')
 __all__ = ('endpoint')
 
 endpoint = Blueprint('endpoint', __name__)
-
-queryTypes = [
-    "CONSTRUCT", "SELECT", "ASK",
-    "DESCRIBE", "INSERT", "DELETE",
-    "CREATE", "CLEAR", "DROP",
-    "LOAD", "COPY", "MOVE", "ADD"]
-queryTypeRegex = r"^(?P<queryType>(" + "|".join(queryTypes) + "))"
-queryTypeModifier = re.VERBOSE | re.IGNORECASE | re.MULTILINE
-queryTypePattern = re.compile(queryTypeRegex, queryTypeModifier)
 
 # querytype: { accept type: [content type, serializer_format]}
 resultSetMimetypes = {
@@ -49,8 +42,16 @@ rdfMimetypes = {
 
 def parse_query_type(query):
     try:
-        return queryTypePattern.search(query).group("queryType").upper()
-    except AttributeError:
+        translatedQuery = translateQuery(parseQuery(query), {}, None)
+        return translatedQuery.algebra.name, translatedQuery
+    except Exception:
+        pass
+
+    try:
+        parsetree = parseUpdate(query)
+        translatedUpdate = translateUpdate(parsetree, {}, None)
+        return parsetree.request[0].name, translatedUpdate
+    except Exception:
         raise UnSupportedQueryType
 
 
@@ -80,7 +81,7 @@ def sparql(branch_or_ref):
 
     if q:
         try:
-            query_type = parse_query_type(q)
+            queryType, parsedQuery = parse_query_type(q)
             graph = quit.instance(branch_or_ref)
         except UnSupportedQueryType as e:
             logger.exception(e)
@@ -89,13 +90,8 @@ def sparql(branch_or_ref):
             logger.exception(e)
             return make_response('No branch or reference given.', 400)
 
-        if query_type not in ['SELECT', 'ASK', 'CONSTRUCT', 'DESCRIBE']:
-            try:
-                res = graph.update(q)
-            except Exception as e:
-                # Update query wrong
-                logger.exception(e)
-                return make_response('Something wrong with your query.', 400)
+        if queryType in ['InsertData', 'DeleteData', 'Modify']:
+            res = graph.update(parsedQuery)
 
             try:
                 ref = request.values.get('ref', None) or default_branch
@@ -110,16 +106,13 @@ def sparql(branch_or_ref):
                 logger.exception(e)
                 return make_response('Error after executing the update query.', 400)
 
-        try:
-            res = graph.query(q)
-        except Exception as e:
-            logger.exception(e)
-            return make_response('Something wrong with your query.', 400)
+        if queryType in ['SelectQuery', 'DescribeQuery', 'AskQuery', 'ConstructQuery']:
+            res = graph.query(parsedQuery)
 
         try:
-            if query_type in ['SELECT', 'ASK']:
+            if queryType in ['SelectQuery', 'AskQuery']:
                 return create_result_response(res, resultSetMimetypes[mimetype])
-            elif query_type in ['CONSTRUCT', 'DESCRIBE']:
+            elif queryType in ['ConstructQuery', 'DescribeQuery']:
                 return create_result_response(res, rdfMimetypes[mimetype])
         except KeyError as e:
             return make_response("Mimetype: {} not acceptable".format(mimetype), 406)
@@ -151,28 +144,22 @@ def provenance():
 
     if q:
         try:
-            query_type = parse_query_type(q)
-            graph = quit.store.store
+            queryType, parsedQuery = parse_query_type(q)
         except UnSupportedQueryType as e:
             logger.exception(e)
             return make_response('Unsupported Query Type', 400)
-        except Exception as e:
-            logger.exception(e)
-            return make_response('Something wrong with query', 400)
 
-        if query_type not in ['SELECT', 'ASK', 'CONSTRUCT', 'DESCRIBE']:
+        graph = quit.store.store
+
+        if queryType not in ['SelectQuery', 'AskQuery', 'ConstructQuery', 'DescribeQuery']:
             return make_response('Unsupported Query Type', 400)
 
-        try:
-            res = graph.query(q)
-        except Exception as e:
-            logger.exception(e)
-            return make_response('Something wrong with your query.', 400)
+        res = graph.query(q)
 
         try:
-            if query_type in ['SELECT', 'ASK']:
+            if queryType in ['SelectQuery', 'AskQuery']:
                 return create_result_response(res, resultSetMimetypes[mimetype])
-            elif query_type in ['CONSTRUCT', 'DESCRIBE']:
+            elif queryType in ['ConstructQuery', 'DescribeQuery']:
                 return create_result_response(res, rdfMimetypes[mimetype])
         except KeyError as e:
             return make_response("Mimetype: {} not acceptable".format(mimetype), 406)

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -15,11 +15,14 @@ __all__ = ('endpoint')
 
 endpoint = Blueprint('endpoint', __name__)
 
-queryTypeRegex = r"""
-    (?P<queryType>(CONSTRUCT|SELECT|ASK|DESCRIBE|INSERT|DELETE|
-    CREATE|CLEAR|DROP|LOAD|COPY|MOVE|ADD))
-"""
-queryTypePattern = re.compile(queryTypeRegex, re.VERBOSE | re.IGNORECASE)
+queryTypes = [
+    "CONSTRUCT", "SELECT", "ASK",
+    "DESCRIBE", "INSERT", "DELETE",
+    "CREATE", "CLEAR", "DROP",
+    "LOAD", "COPY", "MOVE", "ADD"]
+queryTypeRegex = r"^(?P<queryType>(" + "|".join(queryTypes) + "))"
+queryTypeModifier = re.VERBOSE | re.IGNORECASE | re.MULTILINE
+queryTypePattern = re.compile(queryTypeRegex, queryTypeModifier)
 
 # querytype: { accept type: [content type, serializer_format]}
 resultSetMimetypes = {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -235,6 +235,14 @@ class QuitAppTestCase(unittest.TestCase):
             response = app.post('/provenance', data=dict(query=query))
             self.assertEqual(response.status, '200 OK')
 
+            query = "foo bar"
+            response = app.post('/provenance', data=dict(query=query))
+            self.assertEqual(response.status, '400 BAD REQUEST')
+
+            query = "INSERT DATA {graph <urn:graph> {<urn:x> <urn:y> <urn:z> .}}"
+            response = app.post('/provenance', data=dict(query=query))
+            self.assertEqual(response.status, '400 BAD REQUEST')
+
     def testInitAndSelectFromEmptyGraph(self):
         """Test select from newly created app, starting with an empty graph.
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -20,47 +20,55 @@ class QuitEndpointTestCase(unittest.TestCase):
         execution.
         """
         ep = endpoint
-        id_pattern = """ {GRAPH <urn:graph1> { ?s ?p ?o }} WHERE {GRAPH <urn:graph2{ ?s ?p ?o}}"""
+        id_pattern = """ {GRAPH <urn:graph1> { ?s ?p ?o }} WHERE {GRAPH <urn:graph2> { ?s ?p ?o}}"""
 
         queries = {
-            "SELECT * WHERE {graph ?g {?s ?p ?o .}}": 'SELECT',
-            "CONSTRUCT {?s ?p ?o} WHERE {graph ?g {?s ?p ?o .}}": 'CONSTRUCT',
-            'ASK  { ?x foaf:name  "Alice" }': 'ASK',
-            "INSERT DATA { <1> <2> <3> }": 'INSERT',
-            "DELETE DATA { <1> <2> <3> }": 'DELETE',
-            "INSERT " + id_pattern: 'INSERT',
-            "DELETE " + id_pattern: 'DELETE',
-            "INSERT " + id_pattern + '; DELETE' + id_pattern: 'INSERT',
-            "CLEAR  GRAPH <urn:graph1>": 'CLEAR',
-            "CREATE  GRAPH <urn:graph1>": 'CREATE',
-            "DROP  GRAPH <urn:graph1>": 'DROP',
-            "COPY  <urn:graph1> TO <urn:graph2>": 'COPY',
-            "MOVE  <urn:graph1> TO <urn:graph2>": 'MOVE',
-            "ADD  <urn:graph1> TO <urn:graph2>": 'ADD',
-            "LOAD  <urn:graph1> INTO <urn:graph2>": 'LOAD'
+            "SELECT * WHERE {graph ?g {?s ?p ?o .}}": 'SelectQuery',
+            "DESCRIBE ?s WHERE {graph ?g {?s <urn:1> <urn:2> .}}": 'DescribeQuery',
+            "CONSTRUCT {?s ?p ?o} WHERE {graph ?g {?s ?p ?o .}}": 'ConstructQuery',
+            'ASK  { ?x <urn:name>  "Alice" }': 'AskQuery',
+        }
+
+        updates = {
+            "INSERT DATA { <1> <2> <3> }": 'InsertData',
+            "DELETE DATA { <1> <2> <3> }": 'DeleteData',
+            "INSERT " + id_pattern: 'Modify',
+            "DELETE " + id_pattern: 'Modify',
+            "INSERT " + id_pattern + '; DELETE' + id_pattern: 'Modify',
+            "CLEAR  GRAPH <urn:graph1>": 'Clear',
+            "CREATE  GRAPH <urn:graph1>": 'Create',
+            "DROP  GRAPH <urn:graph1>": 'Drop',
+            "COPY  <urn:graph1> TO <urn:graph2>": 'Copy',
+            "MOVE  <urn:graph1> TO <urn:graph2>": 'Move',
+            "ADD  <urn:graph1> TO <urn:graph2>": 'Add',
         }
 
         prefix_queries = {
+            "PREFIX ask: <http://creator/load> INSERT DATA { <1> <2> <3> }": 'InsertData',
             "PREFIX ask: <http://creator/load>\n"
-            "INSERT DATA { <1> <2> <3> }": 'INSERT',
-            "PREFIX ask: <http://creator/load>\n"
-            'ASK  { ?x foaf:name  "Alice" }': 'ASK',
+            'ASK  { ?x <urn:name>  "Alice" }': 'AskQuery',
+            "PREFIX ask: <http://creator/load> DELETE DATA { <1> <2> <3> } ;"
+            "INSERT DATA { <1> <2> <3> } ": 'DeleteData'
+        }
+
+        unsupported_queries = {
+            "foo bar": "unsupported",
+            "LOAD  <urn:graph1> INTO <urn:graph2>": 'Load'
         }
 
         all_queries = chain(
             queries.items(),
-            prefix_queries.items()
+            updates.items(),
+            prefix_queries.items(),
         )
 
         for query, expected in all_queries:
-            try:
-                query_type = ep.parse_query_type(query)
-                self.assertEqual(query_type, expected, query)
-            except UnSupportedQueryType:
-                self.fail("parse_query_type() raised UnSupportedQueryType unexpectedly!")
+            queryType, parsedQuery = ep.parse_query_type(query)
+            self.assertEqual(queryType, expected, query)
 
-        with self.assertRaises(UnSupportedQueryType) as context:
-            ep.parse_query_type('foo bar')
+        for query, expected in unsupported_queries.items():
+            with self.assertRaises(UnSupportedQueryType):
+                ep.parse_query_type(query)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes #79
- [x] prevent regex from matching prefixes
- [x] add tests