### PR TITLE
Fix issue with multiple queries (only first query will be executed)

### DIFF
--- a/quit/core.py
+++ b/quit/core.py
@@ -396,7 +396,6 @@ class Quit(object):
         return self._blobs.get(blob)
 
     def commit(self, graph, delta, message, commit_id, ref, **kwargs):
-
         def build_message(message, kwargs):
             out = list()
             for k, v in kwargs.items():
@@ -435,15 +434,20 @@ class Quit(object):
         except KeyError:
             blobs = []
 
+        removed = set()
         for blob in blobs:
             (fileName, oid) = blob
             try:
                 file_reference, contexts = self.getFileReferenceAndContext(blob, commit)
                 for context in contexts:
-                    changeset = delta.get(context.identifier, [])
-                    if changeset:
-                        _apply(file_reference, changeset, context.identifier)
-                        del delta[context.identifier]
+                    for entry in delta:
+                        delta_dict = entry['delta']
+                        changeset = delta_dict.get(context.identifier, None)
+
+                        if changeset:
+                            _apply(file_reference, changeset, context.identifier)
+                            removed.add(context.identifier)
+                            del(entry['delta'][context.identifier])
 
                 index.add(file_reference.path, file_reference.content)
 
@@ -454,19 +458,26 @@ class Quit(object):
             except KeyError:
                 pass
 
-        if delta:
-            f_name = self.config.getGlobalFile() or 'unassigned.nq'
-            f_new = FileReference(f_name, "")
-            unassigned = set(graph.store.get_context(i) for i in delta.keys())
-            for identifier, changeset in delta.items():
-                if changeset:
-                    _apply(f_new, changeset, graph.store.identifier)
+        unassigned = set()
+        f_name = self.config.getGlobalFile() or 'unassigned.nq'
+        f_new = FileReference(f_name, "")
+        for entry in delta:
+            delta_dict = entry['delta']
+            keys = delta_dict.keys()
+            for key in keys:
+                if key in removed:
+                    continue
+                else:
+                    for identifier, changeset in delta_dict.items():
+                        unassigned.add(identifier)
+                        if changeset and identifier not in removed:
+                            _apply(f_new, changeset['delta'], graph.store.identifier)
 
-            index.add(f_new.path, f_new.content)
+                        index.add(f_new.path, f_new.content)
 
-            blob = f_name, index.stash[f_new.path][0]
-            self._blobs.set(blob, (f_new, unassigned))
-            blobs_new.add(blob)
+                        blob = f_name, index.stash[f_new.path][0]
+                        self._blobs.set(blob, (f_new, unassigned))
+                        blobs_new.add(blob)
 
         message = build_message(message, kwargs)
         author = self.repository._repository.default_signature

--- a/quit/tools/update.py
+++ b/quit/tools/update.py
@@ -337,6 +337,9 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
 
     """
 
+    changes = defaultdict(set)
+    res = []
+
     for u in update:
 
         ctx = QueryContext(graph)
@@ -349,32 +352,32 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
                 ctx[k] = v
             # ctx.push()  # nescessary?
 
-        changes = defaultdict(set)
         try:
             if u.name == 'Load':
-                return evalLoad(ctx, u)
+                res.append(evalLoad(ctx, u))
             elif u.name == 'Clear':
-                return evalClear(ctx, u)
+                evalClear(ctx, u)
             elif u.name == 'Drop':
-                return evalDrop(ctx, u)
+                evalDrop(ctx, u)
             elif u.name == 'Create':
-                return evalCreate(ctx, u)
+                evalCreate(ctx, u)
             elif u.name == 'Add':
-                return evalAdd(ctx, u)
+                evalAdd(ctx, u)
             elif u.name == 'Move':
-                return evalMove(ctx, u)
+                evalMove(ctx, u)
             elif u.name == 'Copy':
-                return evalCopy(ctx, u)
+                evalCopy(ctx, u)
             elif u.name == 'InsertData':
-                return evalInsertData(ctx, u)
+                res.append(evalInsertData(ctx, u))
             elif u.name == 'DeleteData':
-                return evalDeleteData(ctx, u)
+                res.append(evalDeleteData(ctx, u))
             elif u.name == 'DeleteWhere':
-                return evalDeleteWhere(ctx, u)
+                res.append(evalDeleteWhere(ctx, u))
             elif u.name == 'Modify':
-                return evalModify(ctx, u)
+                res.append(evalModify(ctx, u))
             else:
                 raise Exception('Unknown update operation: %s' % (u,))
         except:
             if not u.silent:
                 raise
+    return res

--- a/quit/tools/update.py
+++ b/quit/tools/update.py
@@ -353,7 +353,9 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
 
         try:
             if u.name == 'Load':
-                res.append(evalLoad(ctx, u))
+                result = evalLoad(ctx, u).get('delta', None)
+                if result:
+                    res.append(result)
             elif u.name == 'Clear':
                 evalClear(ctx, u)
             elif u.name == 'Drop':
@@ -367,13 +369,21 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
             elif u.name == 'Copy':
                 evalCopy(ctx, u)
             elif u.name == 'InsertData':
-                res.append(evalInsertData(ctx, u))
+                result = evalInsertData(ctx, u).get('delta', None)
+                if result:
+                    res.append(result)
             elif u.name == 'DeleteData':
-                res.append(evalDeleteData(ctx, u))
+                result = evalDeleteData(ctx, u).get('delta', None)
+                if result:
+                    res.append(result)
             elif u.name == 'DeleteWhere':
-                res.append(evalDeleteWhere(ctx, u))
+                result = evalDeleteWhere(ctx, u).get('delta', None)
+                if result:
+                    res.append(result)
             elif u.name == 'Modify':
-                res.append(evalModify(ctx, u))
+                result = evalModify(ctx, u).get('delta', None)
+                if result:
+                    res.append(result)
             else:
                 raise Exception('Unknown update operation: %s' % (u,))
         except Exception:

--- a/quit/tools/update.py
+++ b/quit/tools/update.py
@@ -15,6 +15,7 @@ from rdflib.plugins.sparql.evaluate import evalBGP, evalPart
 from collections import defaultdict
 from itertools import tee
 
+
 def _append(dct, identifier, action, items):
     if items:
         if not isinstance(identifier, Node):
@@ -337,7 +338,6 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
 
     """
 
-    changes = defaultdict(set)
     res = []
 
     for u in update:
@@ -350,7 +350,6 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
                 if not isinstance(k, Variable):
                     k = Variable(k)
                 ctx[k] = v
-            # ctx.push()  # nescessary?
 
         try:
             if u.name == 'Load':
@@ -377,7 +376,7 @@ def evalUpdate(graph, update, initBindings=None, actionLog=False):
                 res.append(evalModify(ctx, u))
             else:
                 raise Exception('Unknown update operation: %s' % (u,))
-        except:
+        except Exception:
             if not u.silent:
                 raise
     return res

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -99,7 +99,7 @@ def sparql(branch_or_ref):
                 ref = request.values.get('ref', None) or default_branch
                 ref = 'refs/heads/{}'.format(ref)
                 quit.commit(
-                    graph, res.get('delta', None), 'New Commit from QuitStore',
+                    graph, res, 'New Commit from QuitStore',
                     branch_or_ref, ref, query=q
                 )
                 return '', 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -250,7 +250,6 @@ class QuitAppTestCase(unittest.TestCase):
         2. Start Quit
         3. execute SELECT query
         """
-
         # Prepate a git Repository
         with TemporaryRepositoryFactory().withEmptyGraph("http://example.org/") as repo:
 
@@ -279,7 +278,6 @@ class QuitAppTestCase(unittest.TestCase):
         2. Start Quit
         3. execute SELECT query
         """
-
         # Prepate a git Repository
         graphContent = "<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."
         with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as repo:
@@ -316,7 +314,6 @@ class QuitAppTestCase(unittest.TestCase):
         3. execute INSERT DATA query
         4. execute SELECT query
         """
-
         # Prepate a git Repository
         with TemporaryRepositoryFactory().withEmptyGraph("http://example.org/") as repo:
 
@@ -351,7 +348,6 @@ class QuitAppTestCase(unittest.TestCase):
         3. execute INSERT DATA query
         4. execute SELECT query
         """
-
         # Prepate a git Repository
         graphContent = "<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."
         with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as repo:
@@ -378,7 +374,104 @@ class QuitAppTestCase(unittest.TestCase):
 
             self.assertEqual(len(obj["results"]["bindings"]), 2)
 
-            # obj = json.load(select_resp.data)
+            self.assertDictEqual(obj["results"]["bindings"][0], {
+                "s": {'type': 'uri', 'value': 'http://ex.org/a'},
+                "p": {'type': 'uri', 'value': 'http://ex.org/b'},
+                "o": {'type': 'uri', 'value': 'http://ex.org/c'}})
+
+    def testInsertDeleteFromEmptyGraph(self):
+        """Test inserting and deleting data and selecting it, starting with an empty graph.
+
+        1. Prepare a git repository with an empty graph
+        2. Start Quit
+        3. execute INSERT DATA/DELET DATA query
+        4. execute SELECT query
+        """
+        # Prepate a git Repository
+        graphContent = "<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."
+        with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as repo:
+
+            # Start Quit
+            args = quitApp.parseArgs(['-t', repo.workdir, '-cm', 'graphfiles'])
+            objects = quitApp.initialize(args)
+            config = objects['config']
+            app = create_app(config).test_client()
+
+            # fill graph with one triple
+            insert = "INSERT DATA {graph <http://example.org/> {<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> .}}"
+            app.post('/sparql', data=dict(query=insert))
+
+            # execute SELECT query
+            select = "SELECT * WHERE {graph <http://example.org/> {?s ?p ?o .}} ORDER BY ?s ?p ?o"
+            select_resp = app.post('/sparql', data=dict(query=select), headers=dict(accept="application/sparql-results+json"))
+
+            # execute INSERT and DELETE query
+            update = "DELETE DATA {graph <http://example.org/> {<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> .}};"
+            update += "INSERT DATA {graph <http://example.org/> {<http://ex.org/a> <http://ex.org/b> <http://ex.org/c> .}}"
+            app.post('/sparql', data=dict(query=update))
+
+            # test file content
+            expectedFileContent = '<http://ex.org/a> <http://ex.org/b> <http://ex.org/c> <http://example.org/> .'
+            with open(path.join(repo.workdir, 'graph.nq'), 'r') as f:
+                self.assertEqual(expectedFileContent, f.read())
+
+            self.assertFalse(os.path.isfile(path.join(repo.workdir, 'unassigned')))
+
+            # execute SELECT query
+            select = "SELECT * WHERE {graph <http://example.org/> {?s ?p ?o .}} ORDER BY ?s ?p ?o"
+            select_resp = app.post('/sparql', data=dict(query=select), headers=dict(accept="application/sparql-results+json"))
+
+            obj = json.loads(select_resp.data.decode("utf-8"))
+
+            self.assertEqual(len(obj["results"]["bindings"]), 1)
+
+            self.assertDictEqual(obj["results"]["bindings"][0], {
+                "s": {'type': 'uri', 'value': 'http://ex.org/a'},
+                "p": {'type': 'uri', 'value': 'http://ex.org/b'},
+                "o": {'type': 'uri', 'value': 'http://ex.org/c'}})
+
+    def testInsertDeleteFromNonEmptyGraph(self):
+        """Test inserting and deleting data and selecting it, starting with a non empty graph.
+
+        1. Prepare a git repository with a non empty graph
+        2. Start Quit
+        3. execute INSERT DATA/DELET DATA query
+        4. execute SELECT query
+        """
+        # Prepate a git Repository
+        graphContent = "<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> <http://example.org/> ."
+        with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as repo:
+
+            # Start Quit
+            args = quitApp.parseArgs(['-t', repo.workdir, '-cm', 'graphfiles'])
+            objects = quitApp.initialize(args)
+            config = objects['config']
+            app = create_app(config).test_client()
+
+            # execute SELECT query
+            select = "SELECT * WHERE {graph <http://example.org/> {?s ?p ?o .}} ORDER BY ?s ?p ?o"
+            select_resp = app.post('/sparql', data=dict(query=select), headers=dict(accept="application/sparql-results+json"))
+
+            # execute INSERT and DELETE query
+            update = "DELETE DATA {graph <http://example.org/> {<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> .}};"
+            update += "INSERT DATA {graph <http://example.org/> {<http://ex.org/a> <http://ex.org/b> <http://ex.org/c> .}}"
+            app.post('/sparql', data=dict(query=update))
+
+            # test file content
+            expectedFileContent = '<http://ex.org/a> <http://ex.org/b> <http://ex.org/c> <http://example.org/> .'
+            with open(path.join(repo.workdir, 'graph.nq'), 'r') as f:
+                self.assertEqual(expectedFileContent, f.read())
+
+            self.assertFalse(os.path.isfile(path.join(repo.workdir, 'unassigned')))
+
+            # execute SELECT query
+            select = "SELECT * WHERE {graph <http://example.org/> {?s ?p ?o .}} ORDER BY ?s ?p ?o"
+            select_resp = app.post('/sparql', data=dict(query=select), headers=dict(accept="application/sparql-results+json"))
+
+            obj = json.loads(select_resp.data.decode("utf-8"))
+
+            self.assertEqual(len(obj["results"]["bindings"]), 1)
+
             self.assertDictEqual(obj["results"]["bindings"][0], {
                 "s": {'type': 'uri', 'value': 'http://ex.org/a'},
                 "p": {'type': 'uri', 'value': 'http://ex.org/b'},
@@ -737,6 +830,7 @@ class QuitAppTestCase(unittest.TestCase):
 
             response = app.post('/provenance', data=dict(query=query))
             self.assertEqual(response.status, '404 NOT FOUND')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- [x] Fix issue
- [x] Add more tests

When receiving multiple SPARQL queries separated by ';', QuitStore only executed the first query.
With this commit results of each query are stored in a list and are executed during commit method.
Add first test.