### PR TITLE
Change default SELECT query for SPARQL GUI

### DIFF
--- a/quit/web/templates/sparql.html
+++ b/quit/web/templates/sparql.html
@@ -16,6 +16,7 @@
 <script>
     var yasqe = YASQE(document.getElementById("yasqe"), {
     	createShareLink: null,
+      value: 'SELECT * WHERE {\n GRAPH ?g {\n   ?sub ?pred ?obj .\n }\n} \nLIMIT 10',
 		sparql: {
 			showQueryButton: true,
 			endpoint: '{{ request.url }}'

--- a/quit/web/templates/sparql.html
+++ b/quit/web/templates/sparql.html
@@ -16,7 +16,7 @@
 <script>
     var yasqe = YASQE(document.getElementById("yasqe"), {
         createShareLink: null,
-        value: 'SELECT * WHERE {\n GRAPH ?g {\n   ?sub ?pred ?obj .\n }\n} \nLIMIT 10',
+        value: 'SELECT * WHERE {\n GRAPH ?graph {\n   ?sub ?pred ?obj .\n }\n} \nLIMIT 10',
 		sparql: {
 			showQueryButton: true,
 			endpoint: '{{ request.url }}'

--- a/quit/web/templates/sparql.html
+++ b/quit/web/templates/sparql.html
@@ -15,8 +15,8 @@
 <script src="{{ url_for('static', filename='js/yasr.min.js') }}"></script>
 <script>
     var yasqe = YASQE(document.getElementById("yasqe"), {
-    	createShareLink: null,
-      value: 'SELECT * WHERE {\n GRAPH ?g {\n   ?sub ?pred ?obj .\n }\n} \nLIMIT 10',
+        createShareLink: null,
+        value: 'SELECT * WHERE {\n GRAPH ?g {\n   ?sub ?pred ?obj .\n }\n} \nLIMIT 10',
 		sparql: {
 			showQueryButton: true,
 			endpoint: '{{ request.url }}'


### PR DESCRIPTION
SInce QuitStore is based on named graphs, the default SELECT query of the yasqe/yasr interface is changed by searching quads instead of triples.