### PR TITLE
Add a base namespace

### DIFF
--- a/quit/application.py
+++ b/quit/application.py
@@ -68,6 +68,7 @@ def initialize(args):
             repository=args.repourl,
             configmode=args.configmode,
             features=args.features,
+            namespace=args.namespace,
         )
     except InvalidConfigurationError as e:
         logger.error(e)
@@ -120,10 +121,13 @@ def parseArgs(args):
     confighelp = """Path of config file (turtle). Defaults to ./config.ttl."""
     loghelp = """Path to the log file."""
     targethelp = 'The directory of the local store repository.'
+    namespacehelp = """A base namespace that will be applied when dealing with relative URIs in
+                    SPARQL UPDATE queries."""
 
     port_default = 5000
     logfile_default = None
     basepath_default = None
+    namespace_default = 'http://quit.instance/'
     targetdir_default = None
     configfile_default = "config.ttl"
 
@@ -136,6 +140,9 @@ def parseArgs(args):
     if 'QUIT_BASEPATH' in os.environ:
         basepath_default = os.environ['QUIT_BASEPATH']
 
+    if 'QUIT_NAMESPACE' in os.environ:
+        namespace = os.environ['QUIT_NAMESPACE']
+
     if 'QUIT_TARGETDIR' in os.environ:
         targetdir_default = os.environ['QUIT_TARGETDIR']
 
@@ -144,6 +151,8 @@ def parseArgs(args):
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--basepath', type=str, default=basepath_default, help=basepathhelp)
+    parser.add_argument(
+        '-n', '--namespace', type=str, default=namespace_default, help=namespacehelp)
     parser.add_argument('-gc', '--garbagecollection', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('-vv', '--verboseverbose', action='store_true')

--- a/quit/conf.py
+++ b/quit/conf.py
@@ -5,12 +5,13 @@ from os import walk
 from os.path import join, isfile
 from quit.exceptions import MissingConfigurationError, InvalidConfigurationError
 from quit.exceptions import UnknownConfigurationError
+from quit.helpers import isAbsoluteUri
 from rdflib import Graph, ConjunctiveGraph, Literal, Namespace, URIRef, BNode
 from rdflib.plugins.parsers import notation3
 from rdflib.namespace import RDF, NamespaceManager
 from rdflib.util import guess_format
 from urllib.parse import quote, urlparse, urlencode
-from uritools import urisplit, uriunsplit
+from uritools import urisplit
 
 logger = logging.getLogger('quit.conf')
 
@@ -33,7 +34,7 @@ class QuitConfiguration:
         features=None,
         repository=None,
         targetdir=None,
-        namespace='http://quit.instance/'
+        namespace=None
     ):
         """The init method.
 
@@ -75,11 +76,7 @@ class QuitConfiguration:
 
     def __initstoreconfig(self, namespace, repository, targetdir, configfile, configmode):
         """Initialize store settings."""
-        parsed = urisplit(namespace)
-        # We accept Absolute URI as specified in https://tools.ietf.org/html/rfc3986#section-4.3
-        # with http(s) scheme
-        if parsed[0] and parsed[0] in ['http', 'https'] and parsed[1] and not parsed[4] and (
-                parsed[2] == '' or parsed[2] == '/' or os.path.isabs(parsed[2])):
+        if isAbsoluteUri(namespace):
             self.namespace = namespace
         else:
             raise InvalidConfigurationError(

--- a/quit/helpers.py
+++ b/quit/helpers.py
@@ -2,8 +2,10 @@
 
 import logging
 
+import os
 from rdflib.plugins.sparql import parser, algebra
 from rdflib.plugins import sparql
+from uritools import urisplit
 
 logger = logging.getLogger('quit.helpers')
 
@@ -97,3 +99,23 @@ class QueryAnalyzer:
         self.parsedQuery = self.prepareUpdate(querystring)
         self.queryType = 'UPDATE'
         return
+
+
+def isAbsoluteUri(uri):
+    """Check if a URI is a absolute URI and uses 'http(s)' at protocol part.
+
+    Returns:
+        True, if absolute http(s) URIs
+        False, if not
+    """
+    try:
+        parsed = urisplit(uri)
+    except Exception:
+        return False
+    # We accept Absolute URI as specified in https://tools.ietf.org/html/rfc3986#section-4.3
+    # with http(s) scheme
+    if parsed[0] and parsed[0] in ['http', 'https'] and parsed[1] and not parsed[4] and (
+            parsed[2] == '/' or os.path.isabs(parsed[2])):
+        return True
+    else:
+        return False

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -4,6 +4,7 @@ import re
 import logging
 from werkzeug.http import parse_accept_header, parse_options_header
 from flask import Blueprint, request, current_app, make_response, Markup
+from pyparsing import ParseException
 from rdflib import ConjunctiveGraph
 from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
 from rdflib.plugins.sparql.algebra import translateQuery, translateUpdate
@@ -50,7 +51,7 @@ def parse_query_type(query, base=None):
             if value.name == 'Base' and not isAbsoluteUri(value.iri):
                 raise UnSupportedQueryType()
         return translatedQuery.algebra.name, translatedQuery
-    except Exception:
+    except ParseException:
         pass
 
     try:
@@ -61,7 +62,7 @@ def parse_query_type(query, base=None):
             if value.name == 'Base' and not isAbsoluteUri(value.iri):
                 raise UnSupportedQueryType()
         return parsedUpdate.request[0].name, translatedUpdate
-    except Exception:
+    except ParseException:
         raise UnSupportedQueryType
 
 

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -40,16 +40,16 @@ rdfMimetypes = {
 }
 
 
-def parse_query_type(query):
+def parse_query_type(query, base=None):
     try:
-        translatedQuery = translateQuery(parseQuery(query), {}, None)
+        translatedQuery = translateQuery(parseQuery(query), base=base)
         return translatedQuery.algebra.name, translatedQuery
     except Exception:
         pass
 
     try:
         parsetree = parseUpdate(query)
-        translatedUpdate = translateUpdate(parsetree, {}, None)
+        translatedUpdate = translateUpdate(parsetree, base=base)
         return parsetree.request[0].name, translatedUpdate
     except Exception:
         raise UnSupportedQueryType
@@ -116,7 +116,7 @@ def sparql(branch_or_ref):
                                  'to the SPARQL 1.1 standard', 400)
 
     try:
-        queryType, parsedQuery = parse_query_type(query)
+        queryType, parsedQuery = parse_query_type(query, quit.config.namespace)
         graph = quit.instance(branch_or_ref)
     except UnSupportedQueryType as e:
         logger.exception(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flask-cors
 pygit2==0.25.0
 sortedcontainers
 uwsgi
+uritools

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -56,6 +56,23 @@ class TestConfiguration(unittest.TestCase):
 
         return
 
+    def testNamespace(self):
+        init_repository(self.local, False)
+
+        with self.assertRaises(InvalidConfigurationError):
+            QuitConfiguration(configfile=self.localConfigFile, namespace='../')
+
+        good = ['http://example.org/thing#', 'https://example.org/', 'http://example.org/things/']
+        bad = ['file:///home/quit/', 'urn:graph/', 'urn:graph', '../test']
+
+        for uri in good:
+            conf = QuitConfiguration(configfile=self.localConfigFile, namespace=uri)
+            self.assertEqual(conf.namespace, uri)
+
+        for uri in bad:
+            with self.assertRaises(InvalidConfigurationError):
+                QuitConfiguration(configfile=self.localConfigFile, namespace=uri)
+
     def testInitExistingFolder(self):
         conf = QuitConfiguration(configfile=self.localConfigFile)
         self.assertEqual(conf.getRepoPath(), self.local)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -16,6 +16,7 @@ import rdflib
 class TestConfiguration(unittest.TestCase):
 
     def setUp(self):
+        self.ns = 'http://quit.instance/'
         self.testData = './tests/samples/configuration_test'
         self.local = './tests/samples/local'
         self.remote = '.tests/samples/remote'
@@ -59,30 +60,31 @@ class TestConfiguration(unittest.TestCase):
     def testNamespace(self):
         init_repository(self.local, False)
 
-        with self.assertRaises(InvalidConfigurationError):
-            QuitConfiguration(configfile=self.localConfigFile, namespace='../')
+        # missing namespace
+        self.assertRaises(InvalidConfigurationError, QuitConfiguration, 'configfile', self.localConfigFile)
 
         good = ['http://example.org/thing#', 'https://example.org/', 'http://example.org/things/']
         bad = ['file:///home/quit/', 'urn:graph/', 'urn:graph', '../test']
 
+        # good namespaces
         for uri in good:
             conf = QuitConfiguration(configfile=self.localConfigFile, namespace=uri)
             self.assertEqual(conf.namespace, uri)
 
+        # bad namespaces
         for uri in bad:
-            with self.assertRaises(InvalidConfigurationError):
-                QuitConfiguration(configfile=self.localConfigFile, namespace=uri)
+            self.assertRaises(
+                InvalidConfigurationError, QuitConfiguration, 'configfile', self.localConfigFile, 'namespace', uri)
 
     def testInitExistingFolder(self):
-        conf = QuitConfiguration(configfile=self.localConfigFile)
+        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
         self.assertEqual(conf.getRepoPath(), self.local)
 
     def testInitExistingRepo(self):
         init_repository(self.local, False)
 
         conf = QuitConfiguration(
-            configfile=self.localConfigFile
-        )
+            configfile=self.localConfigFile, namespace=self.ns)
 
         conf.initgraphconfig()
 
@@ -91,8 +93,8 @@ class TestConfiguration(unittest.TestCase):
         conf = QuitConfiguration(
             repository='assests/configuration_test',
             configfile=self.localConfigFile,
-            configmode='repoconfig'
-        )
+            configmode='repoconfig',
+            namespace=self.ns)
 
         conf.initgraphconfig()
 
@@ -100,8 +102,8 @@ class TestConfiguration(unittest.TestCase):
 
         conf = QuitConfiguration(
             configfile=self.localConfigFile,
-            configmode='localconfig'
-        )
+            configmode='localconfig',
+            namespace=self.ns)
         conf.initgraphconfig()
 
         self.assertEqual(sorted(conf.getfiles()), ['example1.nq', 'example2.nt'])
@@ -109,15 +111,14 @@ class TestConfiguration(unittest.TestCase):
     def testInitMissingConfiguration(self):
         init_repository(self.local, False)
 
-        with self.assertRaises(InvalidConfigurationError):
-            QuitConfiguration(configfile='no.config')
+        self.assertRaises(InvalidConfigurationError, QuitConfiguration, 'configfile', 'no.config', 'namespace', self.ns)
 
     def testInitWithMissingGraphFiles(self):
         # Mode: fallback to graphfiles
         remove(join(self.local, 'example1.nq'))
         remove(join(self.local, 'example2.nt'))
 
-        conf = QuitConfiguration(configfile=self.remoteConfigFile)
+        conf = QuitConfiguration(configfile=self.remoteConfigFile, namespace=self.ns)
         conf.initgraphconfig()
 
         files = conf.getfiles()
@@ -127,8 +128,8 @@ class TestConfiguration(unittest.TestCase):
         # Mode: graphfiles
         conf = QuitConfiguration(
             configfile=self.localConfigFile,
-            configmode='graphfiles'
-        )
+            configmode='graphfiles',
+            namespace=self.ns)
         conf.initgraphconfig()
 
         files = conf.getfiles()
@@ -138,8 +139,8 @@ class TestConfiguration(unittest.TestCase):
         # Mode: local config file
         conf = QuitConfiguration(
             configfile=self.remoteConfigFile,
-            configmode='localconfig'
-        )
+            configmode='localconfig',
+            namespace=self.ns)
         conf.initgraphconfig()
 
         files = conf.getfiles()
@@ -153,8 +154,8 @@ class TestConfiguration(unittest.TestCase):
         conf = QuitConfiguration(
             repository='assests/configuration_test',
             configfile=self.localConfigFile,
-            configmode='repoconfig'
-        )
+            configmode='repoconfig',
+            namespace=self.ns)
         conf.initgraphconfig()
 
         files = conf.getfiles()
@@ -164,7 +165,7 @@ class TestConfiguration(unittest.TestCase):
 
     def testStoreConfig(self):
         init_repository(self.local, False)
-        conf = QuitConfiguration(configfile=self.localConfigFile)
+        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
 
         self.assertEqual(conf.getRepoPath(), self.local)
         self.assertEqual(conf.getOrigin(), 'git://github.com/aksw/QuitStore.git')
@@ -173,9 +174,7 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(sorted(allFiles), sorted(['config.ttl', 'example1.nq', 'example2.nt', 'example3.nq']))
 
     def testGraphConfigDefaultMode(self):
-        conf = QuitConfiguration(
-                    configfile=self.localConfigFile
-                )
+        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
 
         conf.initgraphconfig()
         graphs = conf.getgraphs()
@@ -205,9 +204,7 @@ class TestConfiguration(unittest.TestCase):
 
     def testGraphConfigLocalConfig(self):
         conf = QuitConfiguration(
-                    configmode='localconfig',
-                    configfile=self.localConfigFile
-                )
+                    configmode='localconfig', configfile=self.localConfigFile, namespace=self.ns)
 
         conf.initgraphconfig()
         graphs = conf.getgraphs()
@@ -233,8 +230,8 @@ class TestConfiguration(unittest.TestCase):
     def testGraphConfigRemoteConfig(self):
         conf = QuitConfiguration(
                     configmode='repoconfig',
-                    configfile=self.localConfigFile
-                )
+                    configfile=self.localConfigFile,
+                    namespace=self.ns)
 
         conf.initgraphconfig()
         graphs = conf.getgraphs()
@@ -260,8 +257,8 @@ class TestConfiguration(unittest.TestCase):
     def testGraphConfigGraphFiles(self):
         conf = QuitConfiguration(
                     configmode='graphfiles',
-                    configfile=self.localConfigFile
-                )
+                    configfile=self.localConfigFile,
+                    namespace=self.ns)
 
         conf.initgraphconfig()
         graphs = conf.getgraphs()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -73,34 +73,54 @@ class QuitEndpointTestCase(unittest.TestCase):
 
     def testBaseNamespace(self):
         ep = endpoint
-        update = "INSERT DATA { <1> <2> <3> }"
+        select = "PREFIX ex: <http://ex.org/> BASE <http://good.example/> SELECT * WHERE { ?s ?p ?o }"
+        update = "PREFIX ex: <http://ex.org/> BASE <http://good.example/> INSERT DATA { <1> <2> <3> }"
+        construct = "PREFIX ex: <http://ex.org/> BASE <http://good.example/> CONSTRUCT { ?s <2> <3> } WHERE { ?s ?p ?o }"
 
-        queryType, parsedQuery = ep.parse_query_type(update, 'http://good.example/')
+        queryType, parsedQuery = ep.parse_query_type(select)
+        self.assertEqual(queryType, 'SelectQuery')
+
+        queryType, parsedQuery = ep.parse_query_type(update)
         self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('http://good.example/1'))
         self.assertEqual(parsedQuery[0]['triples'][0][1], URIRef('http://good.example/2'))
         self.assertEqual(parsedQuery[0]['triples'][0][2], URIRef('http://good.example/3'))
         self.assertEqual(queryType, 'InsertData')
 
-    def testNoneBaseNamespace(self):
-        ep = endpoint
-        update = "INSERT DATA { <1> <2> <3> }"
+        queryType, parsedQuery = ep.parse_query_type(construct)
+        self.assertEqual(queryType, 'ConstructQuery')
 
-        queryType, parsedQuery = ep.parse_query_type(update)
-        self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('1'))
-        self.assertEqual(parsedQuery[0]['triples'][0][1], URIRef('2'))
-        self.assertEqual(parsedQuery[0]['triples'][0][2], URIRef('3'))
-        self.assertEqual(queryType, 'InsertData')
+    def testBadBaseNamespace(self):
+        ep = endpoint
+        select = "PREFIX ex: <http://ex.org/> BASE <bad.example/> SELECT * WHERE { ?s ?p ?o }"
+        update = "PREFIX ex: <http://ex.org/> BASE <bad.example/> INSERT DATA { <1> <2> <3> }"
+        construct = "PREFIX ex: <http://ex.org/> BASE <bad.example/> CONSTRUCT { ?s <2> <3> } WHERE { ?s ?p ?o }"
+
+        self.assertRaises(UnSupportedQueryType, ep.parse_query_type, select)
+        self.assertRaises(UnSupportedQueryType, ep.parse_query_type, update)
+        self.assertRaises(UnSupportedQueryType, ep.parse_query_type, construct)
 
     def testOverwrittenBaseNamespace(self):
         ep = endpoint
-        update = "BASE <http://better.example/> INSERT DATA { <1> <2> <3> }"
+        update1 = "PREFIX ex: <http://ex.org/> INSERT DATA { <1> <2> <3> }"
+        update2 = "PREFIX ex: <http://ex.org/> BASE <http://in-query//> INSERT DATA { <1> <2> <3> }"
 
-        queryType, parsedQuery = ep.parse_query_type(update, 'http://good.example/')
-        self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('http://better.example/1'))
-        self.assertEqual(parsedQuery[0]['triples'][0][1], URIRef('http://better.example/2'))
-        self.assertEqual(parsedQuery[0]['triples'][0][2], URIRef('http://better.example/3'))
+        queryType, parsedQuery = ep.parse_query_type(update1, 'http://argument/')
+        self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('http://argument/1'))
+        self.assertEqual(parsedQuery[0]['triples'][0][1], URIRef('http://argument/2'))
+        self.assertEqual(parsedQuery[0]['triples'][0][2], URIRef('http://argument/3'))
         self.assertEqual(queryType, 'InsertData')
 
+        queryType, parsedQuery = ep.parse_query_type(update2, 'http://argument/')
+        self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('http://in-query/1'))
+        self.assertEqual(parsedQuery[0]['triples'][0][1], URIRef('http://in-query/2'))
+        self.assertEqual(parsedQuery[0]['triples'][0][2], URIRef('http://in-query/3'))
+        self.assertEqual(queryType, 'InsertData')
+
+    def testOverwrittenBadBaseNamespace(self):
+        ep = endpoint
+        update = "PREFIX ex: <http://ex.org/> BASE <bad.base> INSERT DATA { <1> <2> <3> }"
+
+        self.assertRaises(UnSupportedQueryType, ep.parse_query_type, update, 'http://argument/')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -102,7 +102,7 @@ class QuitEndpointTestCase(unittest.TestCase):
     def testOverwrittenBaseNamespace(self):
         ep = endpoint
         update1 = "PREFIX ex: <http://ex.org/> INSERT DATA { <1> <2> <3> }"
-        update2 = "PREFIX ex: <http://ex.org/> BASE <http://in-query//> INSERT DATA { <1> <2> <3> }"
+        update2 = "PREFIX ex: <http://ex.org/> BASE <http://in-query/> INSERT DATA { <1> <2> <3> }"
 
         queryType, parsedQuery = ep.parse_query_type(update1, 'http://argument/')
         self.assertEqual(parsedQuery[0]['triples'][0][0], URIRef('http://argument/1'))


### PR DESCRIPTION
As described in [SPARQL Protocol](https://www.w3.org/TR/sparql11-protocol/#base-iri) we set a default base URI which can be overwritten via command line or via `BASE <IRI>` directly in a SPARQL query.

- [x] Add default base namespace
- [x] Add argument for application
- [x] Add check for absoluteness of URI
- [x] Add test for configuration
- [x] Add test for application
- [x] Add test for endpoint (parse_query_type)