### PR TITLE
Hotfix for commit tree to not crash

### DIFF
--- a/quit/web/extras/commits_graph.py
+++ b/quit/web/extras/commits_graph.py
@@ -70,9 +70,10 @@ def generate_graph_data(commits):
                 routes += [[i, i, b]
                            for i, b in enumerate(reserve[:offset])]
                 reserve.remove(branch)
-                routes.append([offset,
-                               reserve.index(branches[commit.parents[0]]),
-                               branch])
+                parent_branch = branches[commit.parents[0]]
+                if parent_branch in reserve:
+                    reserve_branch = reserve.index(parent_branch)
+                    routes.append([offset, reserve_branch, branch])
             # straight
             else:
                 routes += [[i, i, b] for i, b in enumerate(reserve)]

--- a/quit/web/extras/commits_graph.py
+++ b/quit/web/extras/commits_graph.py
@@ -83,8 +83,9 @@ def generate_graph_data(commits):
             branches[commit.parents[0]] = branch
             routes += [[i, i, b] for i, b in enumerate(reserve)]
             other_branch = get_branch(commit.parents[1])
-            routes.append([offset, reserve.index(other_branch),
-                           other_branch])
+            if other_branch in reserve:
+                routes.append([offset, reserve.index(other_branch),
+                               other_branch])
 
         node = _make_node(commit.sha,
                           offset,


### PR DESCRIPTION
This is a hotfix to make the commit list generation not crash.
 @splattater what do you think about this?