### PR TITLE
Fix repository creation error handling

### DIFF
--- a/quit/git.py
+++ b/quit/git.py
@@ -3,6 +3,7 @@ import pygit2
 import re
 import logging
 
+from _pygit2 import GitError
 from os.path import expanduser, join
 from quit.exceptions import RepositoryNotFound, RevisionNotFound, NodeNotFound, RemoteNotFound
 from quit.exceptions import QuitMergeConflict, QuitGitRefNotFound, QuitGitRepoError
@@ -45,7 +46,7 @@ class Repository(object):
 
         try:
             self._repository = pygit2.Repository(path)
-        except KeyError:
+        except (KeyError, GitError):
             if not create:
                 raise RepositoryNotFound(
                     'Repository "%s" does not exist' % path)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -171,7 +171,7 @@ class GitRepositoryTests(unittest.TestCase):
     def testInitNotExistingsRepo(self):
         dir = TemporaryDirectory()
 
-        repo = quit.git.Repository(self.dir.name)
+        repo = quit.git.Repository(dir.name, create=True)
         self.assertFalse(repo.is_bare)
         self.assertEqual(len(repo.revisions()), 0)
 
@@ -179,7 +179,7 @@ class GitRepositoryTests(unittest.TestCase):
 
     def testInitEmptyRepo(self):
         self.addfile()
-        repo = quit.git.Repository(self.dir.name)
+        repo = quit.git.Repository(self.dir.name, create=True)
         self.assertFalse(repo.is_bare)
         self.assertEqual(len(repo.revisions()), 0)
 


### PR DESCRIPTION
Now we also catch GitError as introduced in 0.25.1
See also: https://github.com/libgit2/pygit2/issues/645 and https://github.com/libgit2/pygit2/pull/698