### PR TITLE
Fix provenance on update

### DIFF
--- a/quit/core.py
+++ b/quit/core.py
@@ -1,6 +1,5 @@
 import pygit2
 
-import copy
 import logging
 
 from pygit2 import GIT_MERGE_ANALYSIS_UP_TO_DATE
@@ -190,7 +189,6 @@ class Quit(object):
         return VirtualGraph(instance)
 
     def changeset(self, commit, delta=None):
-        """Write meta data about a commit to the provenance store."""
 
         if (
             not self.config.hasFeature(Feature.Persistence)
@@ -283,15 +281,14 @@ class Quit(object):
 
                 delta = graphdiff(i2.store if i2 else None, i1.store)
 
-            for index, values in enumerate(delta):
-                for iri, changesets in values.items():
-                    update_uri = QUIT['update-{}-{}'.format(commit.id, index)]
-                    g.add((update_uri, QUIT['graph'], iri))
-                    g.add((commit_uri, QUIT['updates'], update_uri))
-                    for (op, triples) in changesets:
-                        op_uri = QUIT[op + '-' + commit.id]
-                        g.add((update_uri, QUIT[op], op_uri))
-                        g.addN((s, p, o, op_uri) for s, p, o in triples)
+            for index, (iri, changesets) in enumerate(delta.items()):
+                update_uri = QUIT['update-{}-{}'.format(commit.id, index)]
+                g.add((update_uri, QUIT['graph'], iri))
+                g.add((commit_uri, QUIT['updates'], update_uri))
+                for (op, triples) in changesets:
+                    op_uri = QUIT[op + '-' + commit.id]
+                    g.add((update_uri, QUIT[op], op_uri))
+                    g.addN((s, p, o, op_uri) for s, p, o in triples)
 
         # Entities
         map = self.config.getgraphurifilemap()
@@ -449,8 +446,6 @@ class Quit(object):
         if not delta:
             return
 
-        orgdelta = copy.deepcopy(delta)
-
         commit = self.repository.revision(commit_id)
         index = self.repository.index(commit.id)
 
@@ -509,7 +504,7 @@ class Quit(object):
             if not self.repository.is_bare:
                 self.repository._repository.checkout(
                     ref, strategy=pygit2.GIT_CHECKOUT_FORCE)
-            self.syncSingle(commit, orgdelta)
+            self.syncSingle(commit, delta)
 
     def garbagecollection(self):
         """Start garbage collection.

--- a/quit/core.py
+++ b/quit/core.py
@@ -145,9 +145,9 @@ class Quit(object):
                 commit = commits.pop()
                 self.syncSingle(commit)
 
-    def syncSingle(self, commit, delta=None):
+    def syncSingle(self, commit):
         if not self._exists(commit.id):
-            self.changeset(commit, delta)
+            self.changeset(commit)
 
     def instance(self, commit_id=None, force=False):
         """Create and return dataset for a given commit id.
@@ -188,7 +188,7 @@ class Quit(object):
 
         return VirtualGraph(instance)
 
-    def changeset(self, commit, delta=None):
+    def changeset(self, commit):
 
         if (
             not self.config.hasFeature(Feature.Persistence)
@@ -274,12 +274,11 @@ class Quit(object):
                 g.add((commit_uri, PROV["wasInformedBy"], parent_uri))
 
             # Diff
-            if not delta:
-                parent = next(iter(commit.parents or []), None)
+            parent = next(iter(commit.parents or []), None)
 
-                i2 = self.instance(parent.id, True) if parent else None
+            i2 = self.instance(parent.id, True) if parent else None
 
-                delta = graphdiff(i2.store if i2 else None, i1.store)
+            delta = graphdiff(i2.store if i2 else None, i1.store)
 
             for index, (iri, changesets) in enumerate(delta.items()):
                 update_uri = QUIT['update-{}-{}'.format(commit.id, index)]
@@ -504,7 +503,7 @@ class Quit(object):
             if not self.repository.is_bare:
                 self.repository._repository.checkout(
                     ref, strategy=pygit2.GIT_CHECKOUT_FORCE)
-            self.syncSingle(commit, delta)
+            self.syncSingle(commit)
 
     def garbagecollection(self):
         """Start garbage collection.

--- a/quit/utils.py
+++ b/quit/utils.py
@@ -6,6 +6,7 @@ import signal
 import sys
 from datetime import tzinfo, timedelta, datetime
 from quit.graphs import InMemoryAggregatedGraph
+from collections import OrderedDict
 
 ZERO = timedelta(0)
 HOUR = timedelta(hours=1)
@@ -79,7 +80,7 @@ def graphdiff(first, second):
     """
     from rdflib.compare import to_isomorphic, graph_diff
 
-    diffs = {}
+    diffs = OrderedDict()
     iris = set()
 
     if first is not None and isinstance(first, InMemoryAggregatedGraph):
@@ -89,7 +90,7 @@ def graphdiff(first, second):
         second_identifiers = list((g.identifier for g in second.graphs()))
         iris = iris.union(second_identifiers)
 
-    for iri in iris:
+    for iri in sorted(list(iris)):
         changes = diffs.get(iri, [])
 
         if (

--- a/quit/utils.py
+++ b/quit/utils.py
@@ -79,7 +79,7 @@ def graphdiff(first, second):
     """
     from rdflib.compare import to_isomorphic, graph_diff
 
-    diffs = {}
+    diffs = []
     iris = set()
 
     if first is not None and isinstance(first, InMemoryAggregatedGraph):
@@ -90,7 +90,7 @@ def graphdiff(first, second):
         iris = iris.union(second_identifiers)
 
     for iri in iris:
-        changes = diffs.get(iri, [])
+        changes = []
 
         if (
             first is not None and iri in first_identifiers
@@ -112,7 +112,7 @@ def graphdiff(first, second):
         else:
             continue
 
-        diffs[iri] = changes
+        diffs.append({iri: changes})
     return diffs
 
 

--- a/quit/utils.py
+++ b/quit/utils.py
@@ -79,7 +79,7 @@ def graphdiff(first, second):
     """
     from rdflib.compare import to_isomorphic, graph_diff
 
-    diffs = []
+    diffs = {}
     iris = set()
 
     if first is not None and isinstance(first, InMemoryAggregatedGraph):
@@ -90,7 +90,7 @@ def graphdiff(first, second):
         iris = iris.union(second_identifiers)
 
     for iri in iris:
-        changes = []
+        changes = diffs.get(iri, [])
 
         if (
             first is not None and iri in first_identifiers
@@ -112,7 +112,7 @@ def graphdiff(first, second):
         else:
             continue
 
-        diffs.append({iri: changes})
+        diffs[iri] = changes
     return diffs
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -900,9 +900,10 @@ class QuitAppTestCase(unittest.TestCase):
 
         1. Prepare a git repository with an empty and a non empty graph
         2. Start Quit
-        3. execute SELECT query
+        3. execute SELECT queries (/sparql, /provenance)
         4. execute DELETE INSERT WHERE query
-        5. execute SELECT query
+        5. execute SELECT queries (/sparql, /provenance)
+        6. test results
         """
         # Create queries
         prov = 'SELECT DISTINCT ?op ?s ?p ?o '
@@ -1006,9 +1007,9 @@ class QuitAppTestCase(unittest.TestCase):
         1. Prepare a git repository with an empty and a non empty graph
         2. Start Quit
         4. Execute multioperational update query
-        5. Execute SELECT query
+        5. Execute SELECT query against provenace endpoint
         6. Re-start Quit
-        7. Execute SELECT query
+        7. Re-execute SELECT query against provenance endpoint
         8. Compare both query results
         """
         # Create querystrings


### PR DESCRIPTION
Since QuitStore was changed to accept multioperational updates in update.py, the data structure of the produced delta has changed.
Due to missing tests of feature provenance we didn't recognize that the creation of provenance triples wasn't working with this "new" delta. 

- [x] Fix data structure of delta created in graphdiff() (quit.utils)
- [x] Add support for new data structure in changeset() (quit.core)
- [x] Add test
- [x] Manually test (Frontend, Provenance data (SPARQL))