### PR TITLE
Set default host to '::' to start flask with IPv6

### DIFF
--- a/quit/application.py
+++ b/quit/application.py
@@ -207,7 +207,7 @@ def parseArgs(args):
                         default=Feature.Unknown,
                         help=featurehelp)
     parser.add_argument('-p', '--port', default=port_default, type=int)
-    parser.add_argument('--host', default='0.0.0.0', type=str)
+    parser.add_argument('--host', default='::', type=str)
 
     logger.debug("Parsing args: {}".format(args))
 


### PR DESCRIPTION
as of: https://stackoverflow.com/questions/21673068/dual-ipv4-and-ipv6-support-in-flask-applications

This allows dual stack support for quit