### PR TITLE
Forward to pygit2 0.27.2 and libgit2 0.27 branch

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 cd ~
 
-git clone --depth=1 -b maint/v0.25 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b maint/v0.27 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 
 # command to install dependencies
 install:
+    - pip install -U setuptools
     - pip install -r requirements.txt
     - pip install coveralls
     - pip install pylama

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
     - pip install -U setuptools
     - pip install -r requirements.txt
     - pip install coveralls
-    - pip install pylama
+    - pip install pylava
 
 before_script:
-    - "pylama"
+    - "pylava"
 
 # command to run tests
 script:

--- a/pylava.ini
+++ b/pylava.ini
@@ -1,8 +1,8 @@
-[pylama]
+[pylava]
 format = pylint
 skip = tests/*,quit/tools/*
 linters = pep8
 ignore = E402
 
-[pylama:pep8]
+[pylava:pep8]
 max_line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pyyaml
 rdflib>=4.2.2
 rfc3987
 flask-cors
-pygit2==0.25.1
+pygit2==0.27.2
 sortedcontainers
 uwsgi
 uritools


### PR DESCRIPTION
Fix #157.
Use pylava to run on python 3.7.