### PR TITLE
WIP: Add support for SPARQL Update graph management language

### DIFF
--- a/quit/application.py
+++ b/quit/application.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 import os
-from quit.conf import Feature, QuitConfiguration
+from quit.conf import Feature, QuitStoreConfiguration
 from quit.exceptions import InvalidConfigurationError
 import rdflib.plugins.sparql
 from rdflib.plugins.sparql.algebra import SequencePath
@@ -98,11 +98,10 @@ def initialize(args):
         'quit.plugins.serializers.results.htmlresults', 'HTMLResultSerializer')
 
     try:
-        config = QuitConfiguration(
+        config = QuitStoreConfiguration(
             configfile=args.configfile,
             targetdir=args.targetdir,
-            repository=args.repourl,
-            configmode=args.configmode,
+            upstream=args.repourl,
             features=args.features,
             namespace=args.namespace,
         )
@@ -111,14 +110,9 @@ def initialize(args):
         sys.exit('Exiting quit')
 
     # since repo is handled, we can add graphs to config
-    config.initgraphconfig()
 
-    logger.info('QuitStore successfully running.')
-    logger.info('Known graphs: ' + str(config.getgraphs()))
-    logger.info('Known files: ' + str(config.getfiles()))
+    logger.info('QuitStore Configuration initialized.')
     logger.debug('Path of Gitrepo: ' + config.getRepoPath())
-    logger.debug('Config mode: ' + str(config.getConfigMode()))
-    logger.debug('All RDF files found in Gitepo:' + str(config.getgraphsfromdir()))
 
     return {'config': config}
 

--- a/quit/conf.py
+++ b/quit/conf.py
@@ -1,8 +1,9 @@
 import logging
 
 import os
+from pygit2 import Repository
 from os import walk
-from os.path import join, isfile
+from os.path import join, isfile, relpath
 from quit.exceptions import MissingConfigurationError, InvalidConfigurationError
 from quit.exceptions import UnknownConfigurationError
 from quit.helpers import isAbsoluteUri
@@ -25,14 +26,15 @@ class Feature:
 
 
 class QuitConfiguration:
-    """A class that keeps track of the relation between named graphs and files."""
+    quit = Namespace('http://quit.aksw.org/vocab/')
 
+class QuitStoreConfiguration(QuitConfiguration):
+    """A class that provides information about settings, filesystem and git."""
     def __init__(
         self,
-        configmode=None,
         configfile='config.ttl',
         features=None,
-        repository=None,
+        upstream=None,
         targetdir=None,
         namespace=None
     ):
@@ -48,33 +50,24 @@ class QuitConfiguration:
         self.features = features
         self.configchanged = False
         self.sysconf = Graph()
-        self.graphconf = None
-        self.origin = None
-        self.graphs = {}
-        self.files = {}
+        self.upstream = None
         self.namespace = None
 
-        self.quit = Namespace('http://quit.aksw.org/vocab/')
         self.nsMngrSysconf = NamespaceManager(self.sysconf)
         self.nsMngrSysconf.bind('', 'http://quit.aksw.org/vocab/', override=False)
-        self.nsMngrGraphconf = NamespaceManager(self.sysconf)
-        self.nsMngrGraphconf.bind('', 'http://quit.aksw.org/vocab/', override=False)
 
         try:
             self.__initstoreconfig(
                 namespace=namespace,
-                repository=repository,
+                upstream=upstream,
                 targetdir=targetdir,
-                configfile=configfile,
-                configmode=configmode
+                configfile=configfile
             )
         except InvalidConfigurationError as e:
             logger.error(e)
             raise e
 
-        return
-
-    def __initstoreconfig(self, namespace, repository, targetdir, configfile, configmode):
+    def __initstoreconfig(self, namespace, upstream, targetdir, configfile):
         """Initialize store settings."""
         if isAbsoluteUri(namespace):
             self.namespace = namespace
@@ -93,255 +86,41 @@ class QuitConfiguration:
             except PermissionError:
                 raise InvalidConfigurationError(
                     "Configuration file could not be parsed. Permission denied. {}".format(
-                        configfile
-                    )
-                )
+                        configfile))
             except Exception as e:
-                raise UnknownConfigurationError(
-                    "UnknownConfigurationError: {}".format(e)
-                )
+                raise UnknownConfigurationError("UnknownConfigurationError: {}".format(e))
 
             self.configfile = configfile
         else:
             if not targetdir:
                 raise InvalidConfigurationError('No target directory for git repo given')
 
-        if configmode:
-            self.setConfigMode(configmode)
-
         if targetdir:
             self.setRepoPath(targetdir)
 
-        if repository:
-            self.setGitOrigin(repository)
+        if upstream:
+            self.setGitUpstream(upstream)
 
         return
 
-    def initgraphconfig(self):
-        """Initialize graph settings.
+    def hasFeature(self, flags):
+        return flags == (self.features & flags)
 
-        Public method to initalize graph settings. This method will be run only once.
-        """
-        if self.graphconf is None:
-            self.__initgraphconfig()
+    def getBindings(self):
+        ns = Namespace('http://quit.aksw.org/vocab/')
+        q = """SELECT DISTINCT ?prefix ?namespace WHERE {{
+            {{
+                ?ns a <{binding}> ;
+                    <{predicate_prefix}> ?prefix ;
+                    <{predicate_namespace}> ?namespace .
+            }}
+        }}""".format(
+            binding=ns['Binding'], predicate_prefix=ns['prefix'],
+            predicate_namespace=ns['namespace']
+        )
 
-    def __initgraphconfig(self, repository=None, targetdir=None):
-        """Initialize graph settings."""
-        self.graphconf = Graph()
-        configmode = self.getConfigMode()
-        logger.debug("Graph Config mode is: {}".format(configmode))
-
-        if configmode == 'localconfig':
-            self.__initgraphsfromconf(self.configfile)
-        elif configmode == 'repoconfig':
-            remConfigFile = join(self.getRepoPath(), 'config.ttl')
-            self.__initgraphsfromconf(remConfigFile)
-        elif configmode == 'graphfiles':
-            self.__initgraphsfromdir(self.getRepoPath())
-        else:
-            raise InvalidConfigurationError('This mode is not supported.', self.configmode)
-        return
-
-    def __initgraphsfromdir(self, repodir):
-        """Init a repository by analyzing all existing files."""
-        graphs = self.getgraphsfromdir(repodir)
-        repopath = self.getRepoPath()
-
-        for file, format in graphs.items():
-            absgraphfile = os.path.join(repopath, file + '.graph')
-            graphuri = self.__readGraphIriFile(absgraphfile)
-
-            if graphuri and format == 'nquads':
-                self.addgraph(file=file, graphuri=graphuri, format=format)
-            elif graphuri is None and format == 'nquads':
-                tmpgraph = ConjunctiveGraph(identifier='default')
-
-                try:
-                    tmpgraph.parse(source=os.path.join(repopath, file), format=format)
-                except Exception:
-                    logger.error(
-                        "Could not parse graphfile {}. File skipped.".format(file)
-                    )
-                    continue
-
-                namedgraphs = tmpgraph.contexts()
-                founduris = []
-
-                for graph in namedgraphs:
-                    if not isinstance(graph, BNode) and str(graph.identifier) != 'default':
-                        graphuri = graph.identifier
-                        founduris.append(graphuri)
-
-                if len(founduris) == 1:
-                    self.addgraph(file=file, graphuri=graphuri, format=format)
-                elif len(founduris) > 1:
-                    logger.info("No named graph found. {} skipped.".format(file))
-
-                elif len(founduris) < 1:
-                    logger.info(
-                        "More than one named graphs found. Can't decide. {} skipped.".format(
-                            file
-                        )
-                    )
-
-            elif format == 'nt':
-                if graphuri:
-                    self.addgraph(file=file, graphuri=graphuri, format=format)
-                else:
-                    logger.warning('No *.graph file found. ' + file + ' skipped.')
-
-        try:
-            self.__setgraphsfromconf()
-        except InvalidConfigurationError as e:
-            raise e
-
-    def __initgraphsfromconf(self, configfile):
-        """Init graphs with setting from config.ttl."""
-        if not isfile(configfile):
-            raise MissingConfigurationError("Configfile is missing {}".format(configfile))
-
-        try:
-            self.graphconf.parse(configfile, format='turtle')
-        except Exception as e:
-            raise InvalidConfigurationError(
-                "Configfile could not be parsed {} {}".format(configfile, e)
-            )
-
-        # Get Graphs
-        self.__setgraphsfromconf()
-
-    def __readGraphIriFile(self, graphfile):
-        """Search for a graph uri in graph file and return it.
-
-        Args:
-            graphfile: String containing the path of a graph file
-
-        Returns:
-            graphuri: String with the graph URI
-        """
-        try:
-            with open(graphfile, 'r') as f:
-                graphuri = f.readline().strip()
-        except FileNotFoundError:
-            logger.debug("File not found {}".format(graphfile))
-            return
-
-        try:
-            urlparse(graphuri)
-            logger.debug("Graph URI {} found in {}".format(graphuri, graphfile))
-        except Exception:
-            graphuri = None
-            logger.debug("No graph URI found in {}".format(graphfile))
-
-        return graphuri
-
-    def __setgraphsfromconf(self):
-        """Set all URIs and file paths of graphs that are configured in config.ttl."""
-        nsQuit = 'http://quit.aksw.org/vocab/'
-        query = 'SELECT DISTINCT ?graphuri ?filename WHERE { '
-        query += '  ?graph a <' + nsQuit + 'Graph> . '
-        query += '  ?graph <' + nsQuit + 'graphUri> ?graphuri . '
-        query += '  ?graph <' + nsQuit + 'graphFile> ?filename . '
-        query += '}'
-        result = self.graphconf.query(query)
-
-        repopath = self.getRepoPath()
-
-        for row in result:
-            filename = str(row['filename'])
-            format = guess_format(filename)
-            if format not in ['nt', 'nquads']:
-                break
-
-            graphuri = str(row['graphuri'])
-
-            graphFile = join(repopath, filename)
-
-            if isfile(graphFile):
-                # everything is fine
-                pass
-            else:
-                try:
-                    open(graphFile, 'a+').close()
-                except PermissionError:
-                    raise InvalidConfigurationError(
-                        "Permission denied. Can't create file {} in repo {}".format(
-                            graphFile,
-                            self.getRepoPath()
-                        )
-                    )
-                except FileNotFoundError:
-                    raise InvalidConfigurationError(
-                        "File not found. Can't create file {} in repo {}".format(
-                            graphFile,
-                            self.getRepoPath()
-                        )
-                    )
-                except Exception as e:
-                    raise UnknownConfigurationError(
-                        "Can't create file {} in repo {}. Error: {}".format(
-                            graphFile,
-                            self.getRepoPath(),
-                            e
-                        )
-                    )
-
-            graphuri = URIRef(graphuri)
-
-            # we store which named graph is serialized in which file
-            self.graphs[graphuri] = filename
-            # and furthermore we assume that one file can contain data of more
-            # than one named graph and so we store for each file a set of graphs
-            if filename in self.files:
-                self.files[filename]['graphs'].append(graphuri)
-            else:
-                self.files[filename] = {
-                    'serialization': format,
-                    'graphs': [graphuri]
-                }
-
-        return
-
-    def addgraph(self, graphuri, file, format=None):
-        self.graphconf.add((self.quit[quote(graphuri)], RDF.type, self.quit.Graph))
-        self.graphconf.add((self.quit[quote(graphuri)], self.quit.graphUri, URIRef(graphuri)))
-        self.graphconf.add((self.quit[quote(graphuri)], self.quit.graphFile, Literal(file)))
-        if format is not None:
-            self.graphconf.add((self.quit[quote(graphuri)], self.quit.hasFormat, Literal(format)))
-
-        return
-
-    def removegraph(self, graphuri):
-        self.graphconf.remove((self.quit[urlencode(graphuri)], None, None))
-
-        return
-
-    def getConfigMode(self):
-        """Get the mode how Quit-Store detects RDF files and named graphs.
-
-        Returns:
-            A string containig the mode.
-        """
-        nsQuit = 'http://quit.aksw.org/vocab/'
-        property = URIRef(nsQuit + 'configMode')
-
-        for s, p, o in self.sysconf.triples((None, property, None)):
-            return str(o)
-
-        return 'graphfiles'
-
-    def getRepoPath(self):
-        """Get the path of Git repository from configuration.
-
-        Returns:
-            A string containig the path of the git repo.
-        """
-        nsQuit = 'http://quit.aksw.org/vocab/'
-        storeuri = URIRef('http://my.quit.conf/store')
-        property = URIRef(nsQuit + 'pathOfGitRepo')
-
-        for s, p, o in self.sysconf.triples((None, property, None)):
-            return str(o)
+        result = self.sysconf.query(q)
+        return [(row['prefix'], row['namespace']) for row in result]
 
     def getDefaultBranch(self):
         """Get the default branch on the Git repository from configuration.
@@ -361,8 +140,9 @@ class QuitConfiguration:
     def getGlobalFile(self):
         """Get the graph file which should be used for unassigned graphs.
 
-        Returns:
+        Returns
             The filename of the graph file where unassigned graphs should be stored.
+
         """
         nsQuit = 'http://quit.aksw.org/vocab/'
         storeuri = URIRef('http://my.quit.conf/store')
@@ -371,14 +151,224 @@ class QuitConfiguration:
         for s, p, o in self.sysconf.triples((None, property, None)):
             return str(o)
 
-    def getOrigin(self):
+    def getRepoPath(self):
+        """Get the path of Git repository from configuration.
+
+        Returns:
+            A string containig the path of the git repo.
+        """
+        nsQuit = 'http://quit.aksw.org/vocab/'
+        storeuri = URIRef('http://my.quit.conf/store')
+        property = URIRef(nsQuit + 'pathOfGitRepo')
+
+        for s, p, o in self.sysconf.triples((None, property, None)):
+            return str(o)
+
+    def getUpstream(self):
         """Get the URI of Git remote from configuration."""
         nsQuit = 'http://quit.aksw.org/vocab/'
         storeuri = URIRef('http://my.quit.conf/store')
-        property = URIRef(nsQuit + 'origin')
+        property = self.quit.upstream
 
         for s, p, o in self.sysconf.triples((storeuri, property, None)):
             return str(o)
+
+    def setUpstream(self, origin):
+        self.sysconf.remove((None, self.quit.origin, None))
+        self.sysconf.add((self.quit.Store, self.quit.upstream, Literal(origin)))
+
+        return
+
+    def setRepoPath(self, path):
+        self.sysconf.remove((None, self.quit.pathOfGitRepo, None))
+        self.sysconf.add((self.quit.Store, self.quit.pathOfGitRepo, Literal(path)))
+
+        return
+
+
+class QuitGraphConfiguration(QuitConfiguration):
+    """A class that keeps track of the relation between named graphs and files."""
+
+    def __init__(self, repository):
+        """The init method.
+
+        This method checks if the config file is given and reads the config file.
+        If the config file is missing, it will be generated after analyzing the
+        file structure.
+        """
+        logger = logging.getLogger('quit.conf.QuitConfiguration')
+        logger.debug('Initializing configuration object.')
+
+        self.repository = repository
+        self.configfile = None
+        self.mode = None
+        self.graphconf = None
+        self.graphs = {}
+        self.files = {}
+
+    def initgraphconfig(self, rev):
+        """Initialize graph settings.
+
+        Public method to initalize graph settings. This method will be run only once.
+        """
+        if self.graphconf is None:
+            self.graphconf = Graph()
+            self.nsMngrGraphconf = NamespaceManager(self.graphconf)
+            self.nsMngrGraphconf.bind('', 'http://quit.aksw.org/vocab/', override=False)
+
+        rdf_files, config_files = self.get_files_from_repository(rev)
+
+        if len(rdf_files) == 0 and len(config_files) == 0:
+            raise InvalidConfigurationError(
+                "Did not find graphfiles or a QuitStore configuration file.")
+        elif len(rdf_files) > 0 and len(config_files) > 0:
+            raise InvalidConfigurationError(
+                "Conflict. Found graphfiles and QuitStore configuration file.")
+        elif len(rdf_files) > 0:
+            self.mode = 'graphfiles'
+            self.__init_graph_conf_with_blobs(rdf_files, rev)
+        elif len(config_files) == 1:
+            self.mode = 'configuration'
+            self.__init_graph_conf_from_configuration(config_files[0], rev)
+        else:
+            raise InvalidConfigurationError(
+                "Conflict. Found more than one QuitStore configuration file.")
+
+        try:
+            self.__read_graph_conf()
+        except InvalidConfigurationError as e:
+            raise e
+
+    def __init_graph_conf_with_blobs(self, files, rev):
+        """Init a repository by analyzing all existing files."""
+        for file, values in files.items():
+            format = values[0]
+            graphFileId = values[1]
+            graphuri = self.__getUriFromGraphfileBlob(graphFileId)
+
+            if graphuri and format == 'nquads':
+                self.addgraph(file=file, graphuri=graphuri, format=format)
+            elif graphuri is None and format == 'nquads':
+                tmpgraph = ConjunctiveGraph(identifier='default')
+
+                try:
+                    tmpgraph.parse(source=os.path.join(file), format=format)
+                except Exception:
+                    logger.error("Could not parse file {}. File skipped.".format(file))
+                    continue
+
+                namedgraphs = tmpgraph.contexts()
+                founduris = []
+
+                for graph in namedgraphs:
+                    if not isinstance(graph, BNode) and str(graph.identifier) != 'default':
+                        graphuri = graph.identifier
+                        founduris.append(graphuri)
+
+                if len(founduris) == 1:
+                    self.addgraph(file=file, graphuri=graphuri, format=format)
+                elif len(founduris) > 1:
+                    logger.info("No named graph found. {} skipped.".format(file))
+                elif len(founduris) < 1:
+                    logger.info(
+                        "More than one named graphs found. Can't decide. {} skipped.".format(file))
+            elif format == 'nt':
+                if graphuri:
+                    self.addgraph(file=file, graphuri=graphuri, format=format)
+                else:
+                    logger.warning('No *.graph file found. ' + file + ' skipped.')
+
+    def __init_graph_conf_from_configuration(self, configfileId):
+        """Init graphs with setting from config.ttl."""
+        try:
+            configfile = self.repository.get(configfileId)
+        except:
+            raise InvalidConfigurationError(
+                "Blob for configfile with id {} not found in repository {}".format(configfileId, e))
+
+        content = configfile.read_raw()
+
+        try:
+            self.graphconf.parse(data=content, format='turtle')
+        except Exception as e:
+            raise InvalidConfigurationError(
+                "Configfile could not be parsed {} {}".format(configfileId, e)
+            )
+
+    def __getUriFromGraphfileBlob(self, id):
+        """Search for a graph uri in graph file and return it.
+
+        Args:
+            graphfile: String containing the path of a graph file
+
+        Returns:
+            graphuri: String with the graph URI
+        """
+        blob = self.repository.get(id)
+        content = blob.read_raw().decode().strip()
+        uri = urlparse(content.strip())
+        # try:
+        #     with open(graphfile, 'r') as f:
+        #         graphuri = f.readline().strip()
+        # except FileNotFoundError:
+        #     logger.debug("File not found {}".format(graphfile))
+        #     return
+        #
+        # try:
+        #     urlparse(graphuri)
+        #     logger.debug("Graph URI {} found in {}".format(graphuri, graphfile))
+        # except Exception:
+        #     graphuri = None
+        #     logger.debug("No graph URI found in {}".format(graphfile))
+
+        return content
+
+    def __read_graph_conf(self):
+        """Set all URIs and file paths of graphs that are configured in config.ttl."""
+        nsQuit = 'http://quit.aksw.org/vocab/'
+        query = 'SELECT DISTINCT ?graphuri ?filename ?format WHERE { '
+        query += '  ?graph a <' + nsQuit + 'Graph> . '
+        query += '  ?graph <' + nsQuit + 'graphUri> ?graphuri . '
+        query += '  ?graph <' + nsQuit + 'graphFile> ?filename . '
+        query += '  OPTIONAL { ?graph <' + nsQuit + 'hasFormat> ?format .} '
+        query += '}'
+        result = self.graphconf.query(query)
+
+        for row in result:
+            filename = str(row['filename'])
+            if row['format'] is None:
+                format = guess_format(filename)
+            else:
+                format = str(row['format'])
+            if format not in ['nt', 'nquads']:
+                break
+
+            graphuri = URIRef(str(row['graphuri']))
+
+            # we store which named graph is serialized in which file
+            self.graphs[graphuri] = filename
+            # and furthermore we assume that one file can contain data of more
+            # than one named graph and so we store for each file a set of graphs
+            if filename in self.files.keys():
+                self.files[filename]['graphs'].append(graphuri)
+            else:
+                self.files[filename] = {'serialization': format, 'graphs': [graphuri]}
+
+        return
+
+    def addgraph(self, graphuri, file, format=None):
+        self.graphconf.add((self.quit[quote(graphuri)], RDF.type, self.quit.Graph))
+        self.graphconf.add((self.quit[quote(graphuri)], self.quit.graphUri, URIRef(graphuri)))
+        self.graphconf.add((self.quit[quote(graphuri)], self.quit.graphFile, Literal(file)))
+        if format is not None:
+            self.graphconf.add((self.quit[quote(graphuri)], self.quit.hasFormat, Literal(format)))
+
+        return
+
+    def removegraph(self, graphuri):
+        self.graphconf.remove((self.quit[urlencode(graphuri)], None, None))
+
+        return
 
     def getgraphs(self):
         """Get all graphs known to conf.
@@ -386,11 +376,7 @@ class QuitConfiguration:
         Returns:
             A list containig all graph uris as string,
         """
-        graphs = []
-        for graph in self.graphs:
-            graphs.append(graph)
-
-        return graphs
+        return self.graphs
 
     def getfiles(self):
         """Get all files known to conf.
@@ -398,11 +384,7 @@ class QuitConfiguration:
         Returns:
             A list containig all files as string,
         """
-        files = []
-        for file in self.files:
-            files.append(file)
-
-        return files
+        return self.files
 
     def getfileforgraphuri(self, graphuri):
         """Get the file for a given graph uri.
@@ -415,9 +397,9 @@ class QuitConfiguration:
         """
         if isinstance(graphuri, str):
             graphuri = URIRef(graphuri)
-        for uri, filename in self.graphs.items():
-            if uri == graphuri:
-                return filename
+
+        if graphuri in self.graphs.keys():
+            return self.graphs[graphuri]
 
         return
 
@@ -439,7 +421,7 @@ class QuitConfiguration:
         Returns:
             A string containing the RDF serialization of file
         """
-        if file in self.files:
+        if file in self.files.keys():
             return self.files[file]['serialization']
 
         return
@@ -458,61 +440,31 @@ class QuitConfiguration:
 
         return []
 
-    def getgraphsfromdir(self, path=None):
-        """Get the files that are part of the repository (tracked or not).
+    def get_files_from_repository(self, rev):
+        """Get rdf files and QuitStore configuration files from git repository.
 
         Returns:
-            A list of filepathes.
+            A dictionary filepathes and format and a list of configuration files.
         """
-        if path is None:
-            path = self.getRepoPath()
-
-        exclude = set(['.git'])
-
+        configfiles = []
         graphfiles = {}
-        for dirpath, dirs, files in walk(path):
-            dirs[:] = [d for d in dirs if d not in exclude]
-            for filename in files:
+        commit = self.repository.revparse_single(rev)
+        graph_file_blobs = {}
 
-                format = guess_format(join(dirpath, filename))
-                if format is not None:
-                    graphfiles[filename] = format
+        # Collect grahfiles
+        for entry in commit.tree:
+            if entry.type == 'blob' and entry.name.endswith('.graph'):
+                graph_file_blobs[entry.name] = entry.id
 
-        return graphfiles
+        # Collect RDF files and configfiles
+        for entry in commit.tree:
+            if entry.type == 'blob':
+                format = guess_format(entry.name)
+                if entry.name.endswith('quit.ttl') or entry.name.endswith('config.ttl'):
+                    configfiles.append(entry.id)
+                elif format is not None and format in ['nquads', 'nt']:
+                    if str(entry.name) + '.graph' in graph_file_blobs.keys():
+                        graphFileBlobId = graph_file_blobs[entry.name + '.graph']
+                        graphfiles[str(entry.name)] = (format, graphFileBlobId)
 
-    def hasFeature(self, flags):
-        return flags == (self.features & flags)
-
-    def setConfigMode(self, mode):
-        self.sysconf.remove((None, self.quit.configMode, None))
-        self.sysconf.add((self.quit.Store, self.quit.configMode, Literal(mode)))
-
-        return
-
-    def setGitOrigin(self, origin):
-        self.sysconf.remove((None, self.quit.origin, None))
-        self.sysconf.add((self.quit.Store, self.quit.origin, Literal(origin)))
-
-        return
-
-    def setRepoPath(self, path):
-        self.sysconf.remove((None, self.quit.pathOfGitRepo, None))
-        self.sysconf.add((self.quit.Store, self.quit.pathOfGitRepo, Literal(path)))
-
-        return
-
-    def getBindings(self):
-        ns = Namespace('http://quit.aksw.org/vocab/')
-        q = """SELECT DISTINCT ?prefix ?namespace WHERE {{
-            {{
-                ?ns a <{binding}> ;
-                    <{predicate_prefix}> ?prefix ;
-                    <{predicate_namespace}> ?namespace .
-            }}
-        }}""".format(
-            binding=ns['Binding'], predicate_prefix=ns['prefix'],
-            predicate_namespace=ns['namespace']
-        )
-
-        result = self.sysconf.query(q)
-        return [(row['prefix'], row['namespace']) for row in result]
+        return graphfiles, configfiles

--- a/quit/conf.py
+++ b/quit/conf.py
@@ -220,8 +220,7 @@ class QuitGraphConfiguration(QuitConfiguration):
         graph_files, config_files, rdf_files = self.get_blobs_from_repository(rev)
 
         if len(graph_files) == 0 and len(config_files) == 0:
-            raise InvalidConfigurationError(
-                "Did not find graphfiles or a QuitStore configuration file.")
+            self.mode = 'graphfiles'
         elif len(graph_files) > 0 and len(config_files) > 0:
             raise InvalidConfigurationError(
                 "Conflict. Found graphfiles and QuitStore configuration file.")
@@ -465,9 +464,12 @@ class QuitGraphConfiguration(QuitConfiguration):
         """
         config_files = []
         graph_files = {}
-        commit = self.repository.revparse_single(rev)
         graph_file_blobs = {}
         rdf_file_blobs = {}
+        try:
+            commit = self.repository.revparse_single(rev)
+        except Exception:
+            return graph_files, config_files, rdf_file_blobs
 
         # Collect graph files, rdf files and config files
         for entry in commit.tree:

--- a/quit/core.py
+++ b/quit/core.py
@@ -470,7 +470,7 @@ class Quit(object):
             new_contexts = {}
             for entry in delta:
                 for identifier, changeset in entry.items():
-                    if isinstance(identifier, BNode) or identifier == 'default':
+                    if isinstance(identifier, BNode) or str(identifier) == 'default':
                         continue  # TODO
 
                     fileName = quote_plus(identifier + '.nq')

--- a/quit/core.py
+++ b/quit/core.py
@@ -98,6 +98,7 @@ class Quit(object):
         self.store = store
         self._commits = Cache()
         self._blobs = Cache()
+        self._configs = Cache()
 
     def _exists(self, cid):
         uri = QUIT['commit-' + cid]

--- a/quit/helpers.py
+++ b/quit/helpers.py
@@ -7,6 +7,7 @@ from rdflib.term import URIRef
 from rdflib.plugins.sparql.parserutils import CompValue, plist
 from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
 from quit.tools.algebra import translateQuery, translateUpdate
+from rdflib.plugins.serializers.nquads import _nq_row as _nq
 from rdflib.plugins.sparql import parser, algebra
 from rdflib.plugins import sparql
 from uritools import urisplit
@@ -104,6 +105,21 @@ class QueryAnalyzer:
         self.parsedQuery = self.prepareUpdate(querystring)
         self.queryType = 'UPDATE'
         return
+
+
+def applyChangeset(f, changeset, identifier):
+    """Update the FileReference (graph uri) of a file with help of the changeset."""
+    for (op, triples) in changeset:
+        if op == 'additions':
+            for triple in triples:
+                # the internal _nq serializer appends '\n'
+                line = _nq(triple, identifier).rstrip()
+                f.add(line)
+        elif op == 'removals':
+            for triple in triples:
+                # the internal _nq serializer appends '\n'
+                line = _nq(triple, identifier).rstrip()
+                f.remove(line)
 
 
 def isAbsoluteUri(uri):

--- a/quit/helpers.py
+++ b/quit/helpers.py
@@ -120,6 +120,8 @@ def applyChangeset(f, changeset, identifier):
                 # the internal _nq serializer appends '\n'
                 line = _nq(triple, identifier).rstrip()
                 f.remove(line)
+        elif op == 'CREATE':
+            print('erkannt')
 
 
 def isAbsoluteUri(uri):

--- a/quit/web/app.py
+++ b/quit/web/app.py
@@ -107,9 +107,6 @@ def register_app(app, config):
 
     content = quit.store.store.serialize(format='trig').decode()
     logger.debug("Initialize store with following content: {}".format(content))
-    logger.debug("Initialize store with following graphs: {}".format(
-        quit.config.getgraphurifilemap())
-    )
 
     app.config['quit'] = quit
     app.config['blame'] = Blame(quit)

--- a/quit/web/modules/endpoint.py
+++ b/quit/web/modules/endpoint.py
@@ -98,7 +98,7 @@ def sparql(branch_or_ref):
         logger.exception(e)
         return make_response('No branch or reference given.', 400)
 
-    if queryType in ['InsertData', 'DeleteData', 'Modify', 'DeleteWhere']:
+    if queryType in ['InsertData', 'DeleteData', 'Modify', 'DeleteWhere', 'Create']:
         res, exception = graph.update(parsedQuery)
 
         try:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3193,6 +3193,37 @@ class QuitAppTestCase(unittest.TestCase):
                 self.assertEqual('\n', f.read())
 
 
+class GraphManagementTests(unittest.TestCase):
+    def testCreateGraph(self):
+        """Test if a new empty graph file is added.
+
+        1. Prepare a git repository with an empty and a non empty graph
+        2. Start Quit
+        3. execute Update query
+        4. check filesystem for new .nq and .nq.graph file with expected content
+        """
+        # Prepate a git Repository
+        content = '<urn:x> <urn:y> <urn:z> <http://example.org/> .\n'
+        repoContent = {'http://example.org/': content}
+        with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
+
+            # Start Quit
+            args = quitApp.parseArgs(['-t', repo.workdir, '-cm', 'graphfiles'])
+            objects = quitApp.initialize(args)
+            config = objects['config']
+            app = create_app(config).test_client()
+            filename = quote_plus('http://aksw.org/') + '.nq'
+
+            # execute UPDATE query
+            update = 'CREATE GRAPH <http://aksw.org/>'
+            app.post('/sparql',
+                     content_type="application/sparql-update",
+                     data=update)
+
+            with open(path.join(repo.workdir, 'graph_0.nq'), 'r') as f:
+                self.assertEqual('<urn:x> <urn:y> <urn:z> <http://example.org/> .\n', f.read())
+
+
 class FileHandlingTests(unittest.TestCase):
     def testNewNamedGraph(self):
         """Test if a new graph is added to the repository.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -6,280 +6,137 @@ from os import remove
 from os.path import join, isdir
 from pygit2 import init_repository, Repository, clone_repository
 from pygit2 import GIT_SORT_TOPOLOGICAL, GIT_SORT_REVERSE, Signature
-from quit.conf import QuitConfiguration
+from quit.conf import QuitStoreConfiguration, QuitGraphConfiguration
 from quit.exceptions import MissingConfigurationError, InvalidConfigurationError
 from quit.exceptions import MissingFileError
 from distutils.dir_util import copy_tree, remove_tree
+from helpers import TemporaryRepository, TemporaryRepositoryFactory
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import rdflib
 
+
 class TestConfiguration(unittest.TestCase):
 
-    def setUp(self):
-        self.ns = 'http://quit.instance/'
-        self.testData = './tests/samples/configuration_test'
-        self.local = './tests/samples/local'
-        self.remote = '.tests/samples/remote'
-        copy_tree(self.testData, self.local)
-        copy_tree(self.testData, self.remote)
-        self.localConfigFile = join(self.local, 'config.ttl')
-        self.remoteConfigFile = join(self.local, 'config.ttl')
-        tempRepoLine = '  <pathOfGitRepo>  "' + self.local + '" .'
-
-        with open(self.localConfigFile) as f:
-            content = f.readlines()
-
-        remove(self.localConfigFile)
-
-        with open(self.localConfigFile, 'w+') as f:
-            for line in content:
-                if line.startswith('  <pathOfGitRepo'):
-                    f.write(tempRepoLine)
-                else:
-                    f.write(line)
-
-    def tearDown(self):
-        def __deleteFiles(directory):
-            files = glob(join(directory, '*'))
-            for file in files:
-                remove(file)
-
-        __deleteFiles(self.local)
-        __deleteFiles(self.remote)
-
-        localGit = join(self.local, '.git')
-        remoteGit = join(self.remote, '.git')
-
-        if isdir(localGit):
-            remove_tree(localGit)
-        if isdir(remoteGit):
-            remove_tree(remoteGit)
-
-        return
+    ns = 'http://quit.instance/'
 
     def testNamespace(self):
-        init_repository(self.local, False)
+        content1 = '<urn:x> <urn:y> <urn:z> <http://example.org/> .'
+        repoContent = {'http://example.org/': content1}
+        with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
 
-        # missing namespace
-        self.assertRaises(InvalidConfigurationError, QuitConfiguration, 'configfile', self.localConfigFile)
-
-        good = ['http://example.org/thing#', 'https://example.org/', 'http://example.org/things/']
-        bad = ['file:///home/quit/', 'urn:graph/', 'urn:graph', '../test']
-
-        # good namespaces
-        for uri in good:
-            conf = QuitConfiguration(configfile=self.localConfigFile, namespace=uri)
-            self.assertEqual(conf.namespace, uri)
-
-        # bad namespaces
-        for uri in bad:
+            # missing namespace
             self.assertRaises(
-                InvalidConfigurationError, QuitConfiguration, 'configfile', self.localConfigFile, 'namespace', uri)
+                InvalidConfigurationError, QuitStoreConfiguration, 'targetdir', repo.workdir)
 
-    def testInitExistingFolder(self):
-        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
-        self.assertEqual(conf.getRepoPath(), self.local)
+            good = ['http://example.org/thing#', 'https://example.org/', 'http://example.org/things/']
+            bad = ['file:///home/quit/', 'urn:graph/', 'urn:graph', '../test']
 
-    def testInitExistingRepo(self):
-        init_repository(self.local, False)
+            # good namespaces
+            for uri in good:
+                conf = QuitStoreConfiguration(targetdir=repo.workdir, namespace=uri)
+                self.assertEqual(conf.namespace, uri)
 
-        conf = QuitConfiguration(
-            configfile=self.localConfigFile, namespace=self.ns)
+            # bad namespaces
+            for uri in bad:
+                self.assertRaises(
+                    InvalidConfigurationError, QuitStoreConfiguration, 'targetdir', repo.workdir, 'namespace', uri)
 
-        conf.initgraphconfig()
+    def testStoreConfigurationWithDir(self):
+        content1 = '<urn:x> <urn:y> <urn:z> <http://example.org/> .'
+        repoContent = {'http://example.org/': content1}
+        with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
+            conf = QuitStoreConfiguration(targetdir=repo.workdir, namespace=self.ns)
+            self.assertEqual(conf.getRepoPath(), repo.workdir)
 
-        self.assertEqual(sorted(conf.getfiles()), ['example1.nq', 'example2.nt'])
+    def testStoreConfigurationWithConfigfile(self):
+        content1 = '<urn:x> <urn:y> <urn:z> <http://example.org/> .'
+        repoContent = {'http://example.org/': content1}
+        with TemporaryRepositoryFactory().withGraphs(repoContent, 'configfile') as repo:
+            conf = QuitStoreConfiguration(configfile=join(repo.workdir, 'config.ttl'), namespace=self.ns)
+            self.assertEqual(conf.getRepoPath(), repo.workdir)
 
-        conf = QuitConfiguration(
-            repository='assests/configuration_test',
-            configfile=self.localConfigFile,
-            configmode='repoconfig',
-            namespace=self.ns)
+    def testExistingRepoGraphFiles(self):
+        content1 = '<urn:x> <urn:y> <urn:z> <http://example.org/> .'
+        content2 = '<urn:1> <urn:2> <urn:3> <http://example.org/> .\n'
+        content2 += '<urn:a> <urn:b> <urn:c> <http://aksw.org/> .\n'
+        repoContent = {'http://example.org/': content1, 'http://aksw.org/': content2}
+        with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
+            conf = QuitGraphConfiguration(repository=repo)
+            conf.initgraphconfig('master')
 
-        conf.initgraphconfig()
+            graphs = conf.getgraphs()
+            self.assertEqual(
+                sorted([str(x) for x in graphs]), ['http://aksw.org/', 'http://example.org/'])
 
-        self.assertEqual(sorted(conf.getfiles()), ['example1.nq', 'example2.nt'])
+            files = conf.getfiles()
+            self.assertEqual(sorted(files), ['graph_0.nq', 'graph_1.nq'])
 
-        conf = QuitConfiguration(
-            configfile=self.localConfigFile,
-            configmode='localconfig',
-            namespace=self.ns)
-        conf.initgraphconfig()
+            serialization = conf.getserializationoffile('graph_0.nq')
+            self.assertEqual(serialization, 'nquads')
 
-        self.assertEqual(sorted(conf.getfiles()), ['example1.nq', 'example2.nt'])
+            serialization = conf.getserializationoffile('graph_1.nq')
+            self.assertEqual(serialization, 'nquads')
+            gfMap = conf.getgraphurifilemap()
 
-    def testInitMissingConfiguration(self):
-        init_repository(self.local, False)
+            self.assertEqual(gfMap, {
+                    rdflib.term.URIRef('http://aksw.org/'): 'graph_0.nq',
+                    rdflib.term.URIRef('http://example.org/'): 'graph_1.nq'
+                })
 
-        self.assertRaises(InvalidConfigurationError, QuitConfiguration, 'configfile', 'no.config', 'namespace', self.ns)
+            self.assertEqual(
+                [str(x) for x in conf.getgraphuriforfile('graph_0.nq')],
+                ['http://aksw.org/']
+            )
+            self.assertEqual(
+                [str(x) for x in conf.getgraphuriforfile('graph_1.nq')],
+                ['http://example.org/']
+            )
+            self.assertEqual(conf.getfileforgraphuri('http://aksw.org/'), 'graph_0.nq')
+            self.assertEqual(conf.getfileforgraphuri('http://example.org/'), 'graph_1.nq')
 
-    def testInitWithMissingGraphFiles(self):
-        # Mode: fallback to graphfiles
-        remove(join(self.local, 'example1.nq'))
-        remove(join(self.local, 'example2.nt'))
+    def testExistingRepoConfigfile(self):
+        content1 = '<urn:x> <urn:y> <urn:z> <http://example.org/> .'
+        content2 = '<urn:1> <urn:2> <urn:3> <http://example.org/> .\n'
+        content2 += '<urn:a> <urn:b> <urn:c> <http://aksw.org/> .'
+        repoContent = {'http://example.org/': content1, 'http://aksw.org/': content2}
+        with TemporaryRepositoryFactory().withGraphs(repoContent, 'configfile') as repo:
+            conf = QuitGraphConfiguration(repository=repo)
+            conf.initgraphconfig('master')
 
-        conf = QuitConfiguration(configfile=self.remoteConfigFile, namespace=self.ns)
-        conf.initgraphconfig()
+            graphs = conf.getgraphs()
+            self.assertEqual(sorted([str(x) for x in graphs]), ['http://aksw.org/', 'http://example.org/'])
 
-        files = conf.getfiles()
-        # no files to use
-        self.assertEqual(sorted(files), [])
+            files = conf.getfiles()
+            self.assertEqual(sorted(files), ['graph_0.nq', 'graph_1.nq'])
 
-        # Mode: graphfiles
-        conf = QuitConfiguration(
-            configfile=self.localConfigFile,
-            configmode='graphfiles',
-            namespace=self.ns)
-        conf.initgraphconfig()
+            serialization = conf.getserializationoffile('graph_0.nq')
+            self.assertEqual(serialization, 'nquads')
+            serialization = conf.getserializationoffile('graph_1.nq')
+            self.assertEqual(serialization, 'nquads')
 
-        files = conf.getfiles()
-        # no files to use
-        self.assertEqual(sorted(files), [])
+            gfMap = conf.getgraphurifilemap()
+            self.assertEqual(gfMap, {
+                    rdflib.term.URIRef('http://aksw.org/'): 'graph_0.nq',
+                    rdflib.term.URIRef('http://example.org/'): 'graph_1.nq'
+                })
 
-        # Mode: local config file
-        conf = QuitConfiguration(
-            configfile=self.remoteConfigFile,
-            configmode='localconfig',
-            namespace=self.ns)
-        conf.initgraphconfig()
+            self.assertEqual(
+                [str(x) for x in conf.getgraphuriforfile('graph_0.nq')],
+                ['http://aksw.org/']
+            )
+            self.assertEqual(
+                [str(x) for x in conf.getgraphuriforfile('graph_1.nq')], ['http://example.org/']
+            )
+            self.assertEqual(conf.getfileforgraphuri('http://aksw.org/'), 'graph_0.nq')
+            self.assertEqual(conf.getfileforgraphuri('http://example.org/'), 'graph_1.nq')
 
-        files = conf.getfiles()
-        # deleted files should be created
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
+    def testInitWithMissingInformation(self):
+        """Start QuitStore without graphfiles and configfile."""
+        with TemporaryRepositoryFactory().noConfigInformations() as repo:
 
-        # Mode: remote config file
-        remove(join(self.local, 'example1.nq'))
-        remove(join(self.local, 'example2.nt'))
+            conf = QuitGraphConfiguration(repository=repo)
+            self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, 'master')
 
-        conf = QuitConfiguration(
-            repository='assests/configuration_test',
-            configfile=self.localConfigFile,
-            configmode='repoconfig',
-            namespace=self.ns)
-        conf.initgraphconfig()
-
-        files = conf.getfiles()
-        # deleted files should be created
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
-
-
-    def testStoreConfig(self):
-        init_repository(self.local, False)
-        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
-
-        self.assertEqual(conf.getRepoPath(), self.local)
-        self.assertEqual(conf.getOrigin(), 'git://github.com/aksw/QuitStore.git')
-
-        allFiles = conf.getgraphsfromdir()
-        self.assertEqual(sorted(allFiles), sorted(['config.ttl', 'example1.nq', 'example2.nt', 'example3.nq']))
-
-    def testGraphConfigDefaultMode(self):
-        conf = QuitConfiguration(configfile=self.localConfigFile, namespace=self.ns)
-
-        conf.initgraphconfig()
-        graphs = conf.getgraphs()
-        self.assertEqual(sorted([str(x) for x in graphs]), ['http://example.org/2/', 'http://example.org/discovered/'])
-
-        files = conf.getfiles()
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
-
-        serialization = conf.getserializationoffile('example1.nq')
-        self.assertEqual(serialization, 'nquads')
-
-        gfMap = conf.getgraphurifilemap()
-        self.assertEqual(gfMap, {
-                rdflib.term.URIRef('http://example.org/discovered/'): 'example1.nq',
-                rdflib.term.URIRef('http://example.org/2/'): 'example2.nt'
-            })
-
-        self.assertEqual(
-            [str(x) for x in conf.getgraphuriforfile('example1.nq')],
-            ['http://example.org/discovered/']
-        )
-        self.assertEqual(
-            [str(x) for x in conf.getgraphuriforfile('example2.nt')], ['http://example.org/2/']
-        )
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/discovered/'), 'example1.nq')
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/2/'), 'example2.nt')
-
-    def testGraphConfigLocalConfig(self):
-        conf = QuitConfiguration(
-                    configmode='localconfig', configfile=self.localConfigFile, namespace=self.ns)
-
-        conf.initgraphconfig()
-        graphs = conf.getgraphs()
-        self.assertEqual(sorted([str(x) for x in graphs]), ['http://example.org/1/', 'http://example.org/2/'])
-
-        files = conf.getfiles()
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
-
-        serialization = conf.getserializationoffile('example1.nq')
-        self.assertEqual(serialization, 'nquads')
-
-        gfMap = conf.getgraphurifilemap()
-        self.assertEqual(gfMap, {
-                rdflib.term.URIRef('http://example.org/1/'): 'example1.nq',
-                rdflib.term.URIRef('http://example.org/2/'): 'example2.nt'
-            })
-
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example1.nq')], ['http://example.org/1/'])
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example2.nt')], ['http://example.org/2/'])
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/1/'), 'example1.nq')
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/2/'), 'example2.nt')
-
-    def testGraphConfigRemoteConfig(self):
-        conf = QuitConfiguration(
-                    configmode='repoconfig',
-                    configfile=self.localConfigFile,
-                    namespace=self.ns)
-
-        conf.initgraphconfig()
-        graphs = conf.getgraphs()
-        self.assertEqual(sorted([str(x) for x in graphs]), ['http://example.org/1/', 'http://example.org/2/'])
-
-        files = conf.getfiles()
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
-
-        serialization = conf.getserializationoffile('example1.nq')
-        self.assertEqual(serialization, 'nquads')
-
-        gfMap = conf.getgraphurifilemap()
-        self.assertEqual(gfMap, {
-                rdflib.term.URIRef('http://example.org/1/'): 'example1.nq',
-                rdflib.term.URIRef('http://example.org/2/'): 'example2.nt'
-            })
-
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example1.nq')], ['http://example.org/1/'])
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example2.nt')], ['http://example.org/2/'])
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/1/'), 'example1.nq')
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/2/'), 'example2.nt')
-
-    def testGraphConfigGraphFiles(self):
-        conf = QuitConfiguration(
-                    configmode='graphfiles',
-                    configfile=self.localConfigFile,
-                    namespace=self.ns)
-
-        conf.initgraphconfig()
-        graphs = conf.getgraphs()
-        self.assertEqual(sorted([str(x) for x in graphs]), ['http://example.org/2/', 'http://example.org/discovered/'])
-
-        files = conf.getfiles()
-        self.assertEqual(sorted(files), ['example1.nq', 'example2.nt'])
-
-        serialization = conf.getserializationoffile('example1.nq')
-        self.assertEqual(serialization, 'nquads')
-
-        gfMap = conf.getgraphurifilemap()
-        self.assertEqual(gfMap, {
-                rdflib.term.URIRef('http://example.org/discovered/'): 'example1.nq',
-                rdflib.term.URIRef('http://example.org/2/'): 'example2.nt'
-            })
-
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example1.nq')], ['http://example.org/discovered/'])
-        self.assertEqual([str(x) for x in conf.getgraphuriforfile('example2.nt')], ['http://example.org/2/'])
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/discovered/'), 'example1.nq')
-        self.assertEqual(conf.getfileforgraphuri('http://example.org/2/'), 'example2.nt')
 
 def main():
     unittest.main()


### PR DESCRIPTION
Add support for graph management operations (Create, Drop, Copy, Move, Add) of SPARQL Update Language.
Therefor the graph configuration of QuitStore has to be updated for each new commit and delete named graphs must lead do removals of the corresponding RDF file blobs (+ their .graph-file blobs) or the quit.config.ttl-blob.
Allow ADD, CLEAR, CREATE, COPY, DROP, MOVE, LOAD queries.
Since Files may be known to QuitStore or may be unknown and multioperation updates may be incomming we have to prepair the commit.

- [ ] Refactor config
- [ ] Refactor commit
- [ ] Add tests
- [ ] Fix #103
- [ ] Fix #143 