### PR TITLE
Fix whitespace issue in FileReference

### DIFF
--- a/quit/cache.py
+++ b/quit/cache.py
@@ -63,7 +63,7 @@ class FileReference:
         """
 
         if isinstance(content, str):
-            content = content.splitlines() or []
+            content = ' '.join(content.split()).splitlines() or []
 
         self._path = path
         self._content = SortedSet(content)

--- a/quit/cache.py
+++ b/quit/cache.py
@@ -63,7 +63,10 @@ class FileReference:
         """
 
         if isinstance(content, str):
-            content = ' '.join(content.split()).splitlines() or []
+            new = []
+            for line in content.splitlines():
+                new.append(' '.join(line.split()))
+            content = new
 
         self._path = path
         self._content = SortedSet(content)


### PR DESCRIPTION
Valid n-quads-files with additional whitespace won't be matched when patches/changesets appear, since string comparison will be used and quads in patch/changeset are use exactly one whitespace between "spoc."