### PR TITLE
Print coverage result to the build log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,5 @@ deploy:
     repo: AKSW/QuitStore
 
 after_success:
-    coveralls
+    - coverage report -m
+    - coveralls


### PR DESCRIPTION
If the coveralls service is unstable this allows us to get information on the coverage directly from the logs.