### PR TITLE
Disable log file per default in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,8 @@ RUN pip install --no-cache-dir -r requirements.txt \
 COPY docker/config.ttl /etc/quit/
 
 ENV QUIT_CONFIGFILE="/etc/quit/config.ttl"
-ENV QUIT_LOGFILE="/var/log/quit.log"
 
 RUN mkdir /data && chown quit /data
-RUN touch $QUIT_LOGFILE && chown quit $QUIT_LOGFILE
 
 USER quit
 


### PR DESCRIPTION
disable the log file per default, as it just bloats the container