### PR TITLE
Use pytest and setDefaultBranch (master/main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,18 +38,7 @@ jobs:
              git config --global user.email "quittestsystem@example.org"
              git config --global user.name "Quit CI Tests"
       - name: Run Tests
-        run: |
-             poetry run coverage run -a --source=quit tests/test_app.py
-             poetry run coverage run -a --source=quit tests/test_app.py
-             poetry run coverage run -a --source=quit tests/test_cache.py
-             poetry run coverage run -a --source=quit tests/test_conf.py
-             poetry run coverage run -a --source=quit tests/test_core.py
-             poetry run coverage run -a --source=quit tests/test_endpoint.py
-             poetry run coverage run -a --source=quit tests/test_git.py
-             poetry run coverage run -a --source=quit tests/test_graphs.py
-             poetry run coverage run -a --source=quit tests/test_helpers.py
-             poetry run coverage run -a --source=quit tests/test_namespace.py
-             poetry run coverage run -a --source=quit tests/test_provenance.py
+        run: poetry run pytest --cov=quit
       - name: Coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -55,6 +77,9 @@ description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -139,6 +164,14 @@ perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -186,6 +219,40 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -262,6 +329,43 @@ python-versions = ">=3.6"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "rdflib"
 version = "6.1.1"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
@@ -320,6 +424,22 @@ description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "2.0.0"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
@@ -384,9 +504,17 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a8075ccf1034db7fed3ed2a9b423528f2216287d714f90ed6b3c647bb4afe8cb"
+content-hash = "f8e188fe40ae215ccd1719f7519b5697a43a08e697748802e825784b383d7264"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
@@ -527,6 +655,10 @@ importlib-metadata = [
     {file = "importlib_metadata-4.10.0-py3-none-any.whl", hash = "sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4"},
     {file = "importlib_metadata-4.10.0.tar.gz", hash = "sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6"},
 ]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 isodate = [
     {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
     {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
@@ -614,6 +746,18 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
@@ -670,6 +814,14 @@ pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
     {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
 rdflib = [
     {file = "rdflib-6.1.1-py3-none-any.whl", hash = "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"},
     {file = "rdflib-6.1.1.tar.gz", hash = "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754"},
@@ -689,6 +841,14 @@ snowballstemmer = [
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.0-py3-none-any.whl", hash = "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224"},
+    {file = "tomli-2.0.0.tar.gz", hash = "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ uWSGI = "^2.0.20"
 [tool.poetry.dev-dependencies]
 pylava = "^0.3.0"
 coveralls = "^3.3.1"
+pytest = "^6.2.5"
+pytest-cov = "^3.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/quit/core.py
+++ b/quit/core.py
@@ -124,6 +124,12 @@ class Quit(object):
         repository_current_head = self.repository.current_head
         if repository_current_head:
             return repository_current_head
+        try:
+            git_config_default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
+            if git_config_default_branch:
+                return git_config_default_branch
+        except KeyError:
+            pass
         return "master"
 
     def rebuild(self):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -4,6 +4,7 @@ from context import quit
 from glob import glob
 from os import remove
 from os.path import join, isdir
+import pygit2
 from pygit2 import init_repository, Repository, clone_repository
 from pygit2 import GIT_SORT_TOPOLOGICAL, GIT_SORT_REVERSE, Signature
 from quit.conf import QuitStoreConfiguration, QuitGraphConfiguration
@@ -68,8 +69,9 @@ class TestConfiguration(unittest.TestCase):
         content2 += '<urn:a> <urn:b> <urn:c> .\n'
         repoContent = {'http://example.org/': content1, 'http://aksw.org/': content2}
         with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig('master')
+            conf.initgraphconfig(current_head)
             self.assertEqual(conf.mode, 'graphfiles')
 
             graphs = conf.getgraphs()
@@ -103,8 +105,9 @@ class TestConfiguration(unittest.TestCase):
         content3 = '<urn:a> <urn:b> <urn:c> .'
         repoContent = {'no uri': content1, 'http://aksw.org/': content2, '': content3}
         with TemporaryRepositoryFactory().withGraphs(repoContent) as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig('master')
+            conf.initgraphconfig(current_head)
             self.assertEqual(conf.mode, 'graphfiles')
 
             graphs = conf.getgraphs()
@@ -116,6 +119,7 @@ class TestConfiguration(unittest.TestCase):
 
             serialization = conf.getserializationoffile('graph_1.nt')
             self.assertEqual(serialization, 'nt')
+            current_head = repo.head.shorthand
 
             gfMap = conf.getgraphurifilemap()
 
@@ -132,8 +136,9 @@ class TestConfiguration(unittest.TestCase):
         content2 += '<urn:a> <urn:b> <urn:c> .'
         repoContent = {'http://example.org/': content1, 'http://aksw.org/': content2}
         with TemporaryRepositoryFactory().withGraphs(repoContent, 'configfile') as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig('master')
+            conf.initgraphconfig(current_head)
             self.assertEqual(conf.mode, 'configuration')
 
             graphs = conf.getgraphs()
@@ -164,8 +169,9 @@ class TestConfiguration(unittest.TestCase):
         content2 += '<urn:a> <urn:b> <urn:c> .'
         repoContent = {'http://example.org/': content1, 'http://aksw.org/': content2}
         with TemporaryRepositoryFactory().withGraphs(repoContent, 'configfile') as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig('master')
+            conf.initgraphconfig(current_head)
 
             conf.removegraph('http://aksw.org/')
 
@@ -186,18 +192,21 @@ class TestConfiguration(unittest.TestCase):
 
     def testGraphConfigurationFailing(self):
         with TemporaryRepositoryFactory().withBothConfigurations() as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, 'master')
+            self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, current_head)
 
     def testWrongConfigurationFile(self):
         with TemporaryRepositoryFactory().withBothConfigurations() as repo:
+            current_head = repo.head.shorthand
             conf = QuitGraphConfiguration(repository=repo)
-            self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, 'master')
+            self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, current_head)
 
     def testNoConfigInformation(self):
+        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
         with TemporaryRepositoryFactory().withNoConfigInformation() as repo:
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig('master')
+            conf.initgraphconfig(default_branch)
             self.assertEqual(conf.mode, 'graphfiles')
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -15,6 +15,10 @@ from helpers import TemporaryRepository, TemporaryRepositoryFactory
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import rdflib
 
+try:
+    DEFAULT_BRANCH = pygit2.Config.get_global_config()['init.defaultBranch']
+except KeyError:
+    DEFAULT_BRANCH = 'master'
 
 class TestConfiguration(unittest.TestCase):
     ns = 'http://quit.instance/'
@@ -203,10 +207,9 @@ class TestConfiguration(unittest.TestCase):
             self.assertRaises(InvalidConfigurationError, conf.initgraphconfig, current_head)
 
     def testNoConfigInformation(self):
-        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
         with TemporaryRepositoryFactory().withNoConfigInformation() as repo:
             conf = QuitGraphConfiguration(repository=repo)
-            conf.initgraphconfig(default_branch)
+            conf.initgraphconfig(DEFAULT_BRANCH)
             self.assertEqual(conf.mode, 'graphfiles')
 
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -12,6 +12,12 @@ from tempfile import TemporaryDirectory, NamedTemporaryFile
 import subprocess
 from helpers import createCommit, TemporaryRepository, TemporaryRepositoryFactory
 
+try:
+    DEFAULT_BRANCH = pygit2.Config.get_global_config()['init.defaultBranch']
+except KeyError:
+    DEFAULT_BRANCH = 'master'
+
+
 class GitRevisionTests(unittest.TestCase):
 
     def setUp(self):
@@ -235,8 +241,6 @@ class GitRepositoryTests(unittest.TestCase):
 
     def testPushRepo(self):
         """Test if it is possible to push to an empty remote repository."""
-        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
-
         with TemporaryRepository(True) as remote:
             graphContent = """
                 <http://ex.org/x> <http://ex.org/y> <http://ex.org/z> ."""
@@ -247,21 +251,20 @@ class GitRepositoryTests(unittest.TestCase):
                 self.assertTrue(remote.is_empty)
                 self.assertFalse(local.is_empty)
 
-                quitRepo.push("origin", default_branch)
+                quitRepo.push("origin", DEFAULT_BRANCH)
 
                 self.assertFalse(remote.is_empty)
                 self.assertFalse(local.is_empty)
 
     def testPushRefspecs(self):
         """Test if it is possible to push to an empty remote repository."""
-        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
 
         for refspec in [
-            default_branch, 'refs/heads/' + default_branch,
-            'refs/heads/' + default_branch + ':' + default_branch,
-            default_branch + ':' + default_branch,
-            default_branch + ':refs/heads/' + default_branch,
-            'refs/heads/' + default_branch + ':refs/heads/' + default_branch
+            DEFAULT_BRANCH, 'refs/heads/' + DEFAULT_BRANCH,
+            'refs/heads/' + DEFAULT_BRANCH + ':' + DEFAULT_BRANCH,
+            DEFAULT_BRANCH + ':' + DEFAULT_BRANCH,
+            DEFAULT_BRANCH + ':refs/heads/' + DEFAULT_BRANCH,
+            'refs/heads/' + DEFAULT_BRANCH + ':refs/heads/' + DEFAULT_BRANCH
         ]:
             with TemporaryRepository(True) as remote:
                 graphContent = """
@@ -280,8 +283,6 @@ class GitRepositoryTests(unittest.TestCase):
 
     def testPushRepoNotConfiguredRemote(self):
         """Test if the push failes if the origin remote was not defined."""
-        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
-
         with TemporaryRepository(True) as remote:
             graphContent = """
                 <http://ex.org/x> <http://ex.org/y> <http://ex.org/z> ."""
@@ -293,15 +294,13 @@ class GitRepositoryTests(unittest.TestCase):
                 self.assertFalse(local.is_empty)
 
                 with self.assertRaises(RemoteNotFound):
-                    quitRepo.push("origin", default_branch)
+                    quitRepo.push("origin", DEFAULT_BRANCH)
 
                 self.assertTrue(remote.is_empty)
                 self.assertFalse(local.is_empty)
 
     def testPushRepoWithRemoteName(self):
         """Test if it is possible to push to a remote repository, which is not called orign."""
-        default_branch = pygit2.Config.get_global_config()['init.defaultBranch']
-
         with TemporaryRepository(True) as remote:
             graphContent = "<http://ex.org/x> <http://ex.org/y> <http://ex.org/z> ."
             with TemporaryRepositoryFactory().withGraph("http://example.org/", graphContent) as local:
@@ -311,7 +310,7 @@ class GitRepositoryTests(unittest.TestCase):
                 self.assertTrue(remote.is_empty)
                 self.assertFalse(local.is_empty)
 
-                quitRepo.push("upstream", default_branch)
+                quitRepo.push("upstream", DEFAULT_BRANCH)
 
                 self.assertFalse(remote.is_empty)
                 self.assertFalse(local.is_empty)


### PR DESCRIPTION
In this pull-request, the testing system is changed to pytest (https://pytest.org/).
Since we have tested the new setup on systems, that have set the default branch to `main` we have made the tests robust to different default branch names as well.

Fix #294.